### PR TITLE
NSHMP rupture floating; Location updates and tests

### DIFF
--- a/src/org/opensha2/calc/GridCalc.java
+++ b/src/org/opensha2/calc/GridCalc.java
@@ -46,6 +46,7 @@ import com.google.common.primitives.Doubles;
  *
  * @author Peter Powers
  */
+@Deprecated
 public class GridCalc {
 
 	// TODO reorganize, clean, privatize
@@ -171,10 +172,11 @@ public class GridCalc {
 //			double[] distances = DataTable.Builder.create().rows(rMin, rMax, rΔ).rows();
 			double[] distances = DataTables.keys(rMin, rMax, rΔ);
 			
-			LocationList locations = LocationList.create(
-				SRC_LOC,
-				Doubles.asList(distances),
-				SRC_TO_SITE_AZIMUTH);
+			LocationList locations = null;
+//			LocationList locations = LocationList.create(
+//				SRC_LOC,
+//				Doubles.asList(distances),
+//				SRC_TO_SITE_AZIMUTH);
 
 			List<Site> siteList = createSiteList(locations, vs30);
 

--- a/src/org/opensha2/calc/Results.java
+++ b/src/org/opensha2/calc/Results.java
@@ -88,7 +88,7 @@ public class Results {
 	public static void writeResultsOLD(Path dir, List<Hazard> batch, OpenOption... options)
 			throws IOException {
 
-		Function<Double, String> locFmtFunc = Parsing.formatDoubleFunction(Location.FORMAT);
+		Function<Double, String> locFmtFunc = Parsing.formatDoubleFunction("%.5f");
 		Function<Double, String> rateFmtFunc = Parsing.formatDoubleFunction(RATE_FMT);
 
 		Hazard demo = batch.get(0);
@@ -210,8 +210,8 @@ public class Results {
 			String name = namedSites ? hazard.site.name : null;
 			List<String> locData = Lists.newArrayList(
 				name,
-				String.format(Location.FORMAT, hazard.site.location.lon()),
-				String.format(Location.FORMAT, hazard.site.location.lat()));
+				String.format("%.5f", hazard.site.location.lon()),
+				String.format("%.5f", hazard.site.location.lat()));
 
 			Map<Imt, Map<SourceType, XySequence>> curvesByType = detailed ?
 				curvesByType(hazard) : null;

--- a/src/org/opensha2/eq/fault/Faults.java
+++ b/src/org/opensha2/eq/fault/Faults.java
@@ -185,8 +185,7 @@ public final class Faults {
 	 * @return the supplied trace for use inline
 	 */
 	public static LocationList validateTrace(LocationList trace) {
-		checkArgument(checkNotNull(trace, "Trace may not be null").size() > 1,
-			"Trace must have at least 2 points");
+		checkArgument(checkNotNull(trace).size() > 1, "Trace must have at least 2 points");
 		return trace;
 	}
 

--- a/src/org/opensha2/eq/fault/surface/ApproxGriddedSurface.java
+++ b/src/org/opensha2/eq/fault/surface/ApproxGriddedSurface.java
@@ -172,7 +172,7 @@ public class ApproxGriddedSurface extends AbstractGriddedSurface {
 		double avgDip = (vFirst.plungeDegrees() + vLast.plungeDegrees()) / 2;
 		avgDipRad = avgDip * GeoTools.TO_RAD;
 		
-		avgDepth = upperTrace.averageDepth();
+		avgDepth = upperTrace.depth();
 		
 		centroid = Locations.centroid(this);
 	}

--- a/src/org/opensha2/eq/fault/surface/DefaultGriddedSurface.java
+++ b/src/org/opensha2/eq/fault/surface/DefaultGriddedSurface.java
@@ -64,69 +64,14 @@ public class DefaultGriddedSurface extends AbstractGriddedSurface {
 		// compute actual (best fit) spacings
 		double length = trace.length();
 		this.strikeSpacing = length / Math.ceil(length / strikeSpacing);
-		// double downDipWidth = (lowerDepth-depth)/Math.sin(dip *
-		// GeoTools.TO_RAD);
 		this.dipSpacing = width / Math.ceil(width / dipSpacing);
 
-		// set(trace, dip, depth, lowerDepth, strikeSpacing, dipSpacing);
-		// this.lowerDepth = lowerDepth;
-		// this.strikeSpacing = gridSpacingAlong;
-		// this.gridSpacingDown = dipSpacing;
-		// this.sameGridSpacing = true;
-		// if(dipSpacing != gridSpacingAlong) sameGridSpacing = false;
 
 		createEvenlyGriddedSurface();
 
 		centroid = Locations.centroid(this);
 	}
 
-	// private void set(LocationList faultTrace, double dip, double depth,
-	// double lowerDepth, double strikeSpacing, double dipSpacing) {
-	// this.trace =faultTrace;
-	// this.aveDip =dip;
-	// this.upperSeismogenicDepth = depth;
-	// this.lowerSeismogenicDepth =lowerDepth;
-	// this.gridSpacingAlong = strikeSpacing;
-	// this.gridSpacingDown = dipSpacing;
-	// this.sameGridSpacing = true;
-	// if(dipSpacing != strikeSpacing) sameGridSpacing = false;
-	// }
-	//
-
-	// private void assertValidState() {
-
-	// TODO revisit; should only need to validate derived values; all value
-	// from constructor should be valid
-
-	// checkNotNull(trace, "Fault Trace is null");
-	// if( trace == null ) throw new FaultException(C + "Fault Trace is null");
-
-	// Faults.validateDip(dip);
-	// Faults.validateDepth(lowerDepth);
-	// Faults.validateDepth(depth);
-	// checkArgument(depth < lowerDepth);
-
-	// checkArgument(!Double.isNaN(strikeSpacing), "invalid gridSpacing");
-	// if( strikeSpacing == Double.NaN ) throw new FaultException(C +
-	// "invalid gridSpacing");
-
-	// double depth = trace.first().depth();
-	// checkArgument(depth <= depth,
-	// "depth on trace locations %s must be <= upperSeisDepth %s",
-	// depth, depth);
-	// if(depth > depth)
-	// throw new FaultException(C +
-	// "depth on trace locations must be < upperSeisDepth");
-
-	// for (Location loc : trace) {
-	// if (loc.depth() != depth) {
-	// checkArgument(loc.depth() == depth,
-	// "All depth on trace locations must be equal");
-	// // throw new FaultException(C +
-	// ":All depth on trace locations must be equal");
-	// }
-	// }
-	// }
 
 	/**
 	 * Return a new surface builder.
@@ -250,10 +195,6 @@ public class DefaultGriddedSurface extends AbstractGriddedSurface {
 	 */
 	private void createEvenlyGriddedSurface() {
 
-		// if( D ) System.out.println("Starting createEvenlyGriddedSurface");
-
-		// assertValidState();
-
 		final int numSegments = trace.size() - 1;
 		// final double avDipRadians = dip * GeoTools.TO_RAD;
 		final double gridSpacingCosAveDipRadians = dipSpacing * Math.cos(dipRad);
@@ -268,16 +209,6 @@ public class DefaultGriddedSurface extends AbstractGriddedSurface {
 
 		Location firstLoc;
 		Location lastLoc;
-		// double aveDipDirectionRad;
-		// // Find ave dip direction (defined by end locations):
-		// if( Double.isNaN(dipDir) ) {
-		// aveDipDirectionRad = Faults.dipDirectionRad(trace);
-		// } else {
-		// aveDipDirectionRad = dipDir * GeoTools.TO_RAD;
-		// }
-
-		// if(D) System.out.println("\taveDipDirection = " + aveDipDirectionRad
-		// * GeoTools.TO_DEG);
 
 		// Iterate over each Location in Fault Trace
 		// Calculate distance, cumulativeDistance and azimuth for
@@ -305,45 +236,23 @@ public class DefaultGriddedSurface extends AbstractGriddedSurface {
 
 		}
 
-		// Calculate down dip width
-		// double downDipWidth = (lowerDepth-depth)/Math.sin( avDipRadians );
-
 		// Calculate the number of rows and columns
 		int rows = 1 + Math.round((float) (width / dipSpacing));
 		int cols = 1 + Math.round((float) (segmentCumLenth[numSegments - 1] / strikeSpacing));
 
-		// if(D) System.out.println("numLocs: = " + trace.size());
-		// if(D) System.out.println("numSegments: = " + numSegments);
-		// if(D) System.out.println("firstLoc: = " + firstLoc);
-		// if(D) System.out.println("lastLoc(): = " + lastLoc);
-		// if(D) System.out.println("downDipWidth: = " + downDipWidth);
-		// if(D) System.out.println("totTraceLength: = " + segmentCumLenth[
-		// numSegments - 1]);
-		// if(D) System.out.println("numRows: = " + rows);
-		// if(D) System.out.println("numCols: = " + cols);
-
 		// Create GriddedSurface
 		int segmentNumber, ith_row, ith_col = 0;
 		double distanceAlong, distance, hDistance, vDistance;
-		// location object
 		Location location1;
 
-		// initialize the num of Rows and Cols for the container2d object that
-		// holds
+		// initialize the num of Rows and Cols for the container2d object
 		setNumRowsAndNumCols(rows, cols);
 
 		// Loop over each column - ith_col is ith grid step along the fault
-		// trace
-		// if( D ) System.out.println("   Iterating over columns up to " + cols
-		// );
 		while (ith_col < cols) {
-
-			// if( D ) System.out.println("   ith_col = " + ith_col);
 
 			// calculate distance from column number and grid spacing
 			distanceAlong = ith_col * strikeSpacing;
-			// if( D ) System.out.println("   distanceAlongFault = " +
-			// distanceAlong);
 
 			// Determine which segment distanceAlong is in
 			segmentNumber = 1;
@@ -355,22 +264,15 @@ public class DefaultGriddedSurface extends AbstractGriddedSurface {
 			// off the end
 			if (segmentNumber == numSegments + 1) segmentNumber--;
 
-			// if( D ) System.out.println("   segmentNumber " + segmentNumber );
-
 			// Calculate the distance from the last segment point
-			if (segmentNumber > 1)
+			if (segmentNumber > 1) {
 				distance = distanceAlong - segmentCumLenth[segmentNumber - 2];
-			else
+			} else {
 				distance = distanceAlong;
-			// if( D ) System.out.println("   distanceFromLastSegPt " + distance
-			// );
+			}
 
 			// Calculate the grid location along fault trace and put into grid
 			location1 = trace.get(segmentNumber - 1);
-			// dir = new LocationVector(0, distance, segmentAzimuth[
-			// segmentNumber - 1 ], 0);
-			// dir = new LocationVector(segmentAzimuth[ segmentNumber - 1 ],
-			// distance, 0);
 			dir = LocationVector.create(segmentAzimuth[segmentNumber - 1], distance, 0);
 
 			// location on the trace
@@ -428,21 +330,6 @@ public class DefaultGriddedSurface extends AbstractGriddedSurface {
 			ith_col++;
 		}
 
-		// if( D ) System.out.println("Ending createEvenlyGriddedSurface");
-
-		/*
-		 * // test for fittings surfaces exactly
-		 * if((float)(trace.getTraceLength()-getSurfaceLength()) != 0.0)
-		 * System.out.println(trace.getName()+"\n\t"+
-		 * "LengthDiff="+(float)(trace.getTraceLength()-getSurfaceLength())+
-		 * "\t"
-		 * +(float)trace.getTraceLength()+"\t"+(float)getSurfaceLength()+"\t"
-		 * +getNumCols()+"\t"+(float)getGridSpacingAlongStrike()+
-		 * "\n\tWidthDiff="+(float)(downDipWidth-getSurfaceWidth())
-		 * +"\t"+(float)
-		 * (downDipWidth)+"\t"+(float)getSurfaceWidth()+"\t"+getNumRows
-		 * ()+"\t"+(float)getGridSpacingDownDip());
-		 */
 	}
 
 	// Surely the creation of a gridded surface can be easier...
@@ -486,7 +373,6 @@ public class DefaultGriddedSurface extends AbstractGriddedSurface {
 	 */
 	public static LocationList resampleTrace(LocationList trace, int num) {
 		double resampInt = trace.length() / num;
-		// FaultTrace resampTrace = new FaultTrace("resampled "+trace.name());
 		List<Location> resampLocs = Lists.newArrayList();
 		resampLocs.add(trace.first()); // add the first location
 		double remainingLength = resampInt;
@@ -496,12 +382,6 @@ public class DefaultGriddedSurface extends AbstractGriddedSurface {
 			Location nextLoc = trace.get(NextLocIndex);
 			double length = linearDistanceFast(lastLoc, nextLoc);
 			if (length > remainingLength) {
-				// set the point
-				// LocationVector dir = vector(lastLoc, nextLoc);
-				// dir.setHorzDistance(dir.getHorzDistance() * remainingLength /
-				// length);
-				// dir.setVertDistance(dir.getVertDistance() * remainingLength /
-				// length);
 				LocationVector dirSrc = LocationVector.create(lastLoc, nextLoc);
 				double hDist = dirSrc.horizontal() * remainingLength / length;
 				double vDist = dirSrc.vertical() * remainingLength / length;
@@ -518,50 +398,11 @@ public class DefaultGriddedSurface extends AbstractGriddedSurface {
 			}
 		}
 
-		// make sure we got the last one (might be missed because of numerical
-		// precision issues?)
+		// make sure we got the last one
+		// (might be missed because of numerical precision issues?)
 		double dist = linearDistanceFast(trace.last(), resampLocs.get(resampLocs.size() - 1));
 		if (dist > resampInt / 2) resampLocs.add(trace.last());
 
-		/* Debugging Stuff **************** */
-		/*
-		 * // write out each to check System.out.println("RESAMPLED"); for(int
-		 * i=0; i<resampTrace.size(); i++) { Location l =
-		 * resampTrace.getLocationAt(i);
-		 * System.out.println(l.getLatitude()+"\t"+
-		 * l.getLongitude()+"\t"+l.getDepth()); }
-		 * 
-		 * System.out.println("ORIGINAL"); for(int i=0; i<trace.size(); i++) {
-		 * Location l = trace.getLocationAt(i);
-		 * System.out.println(l.getLatitude(
-		 * )+"\t"+l.getLongitude()+"\t"+l.getDepth()); }
-		 * 
-		 * // write out each to check
-		 * System.out.println("target resampInt="+resampInt+"\tnum sect="+num);
-		 * System.out.println("RESAMPLED"); double ave=0, min=Double.MAX_VALUE,
-		 * max=Double.MIN_VALUE; for(int i=1; i<resampTrace.size(); i++) {
-		 * double d = Locations.getTotalDistance(resampTrace.getLocationAt(i-1),
-		 * resampTrace.getLocationAt(i)); ave +=d; if(d<min) min=d; if(d>max)
-		 * max=d; } ave /= resampTrace.size()-1;
-		 * System.out.println("ave="+ave+"\tmin="
-		 * +min+"\tmax="+max+"\tnum pts="+resampTrace.size());
-		 * 
-		 * 
-		 * System.out.println("ORIGINAL"); ave=0; min=Double.MAX_VALUE;
-		 * max=Double.MIN_VALUE; for(int i=1; i<trace.size(); i++) { double d =
-		 * Locations.getTotalDistance(trace.getLocationAt(i-1),
-		 * trace.getLocationAt(i)); ave +=d; if(d<min) min=d; if(d>max) max=d; }
-		 * ave /= trace.size()-1;
-		 * System.out.println("ave="+ave+"\tmin="+min+"\tmax="
-		 * +max+"\tnum pts="+trace.size());
-		 * 
-		 * /* End of debugging stuff *******************
-		 */
-
-		// TODO is resampled trace name used? can't it be acquired from a
-		// wrapping source?
-		// return FaultTrace.create("resampled " + trace.name(),
-		// LocationList.create(resampLocs));
 		return LocationList.create(resampLocs);
 	}
 
@@ -570,31 +411,11 @@ public class DefaultGriddedSurface extends AbstractGriddedSurface {
 	 */
 	@Override public LocationList getPerimeter() {
 
-		// LocationList topTrace = new LocationList();
 		List<Location> topLocs = Lists.newArrayList();
-		// LocationList botTrace = new LocationList();
 		List<Location> botLocs = Lists.newArrayList();
-		// final double avDipRadians = dip * GeoTools.TO_RAD;
-		// double aveDipDirectionRad;
-		// if( Double.isNaN(dipDir) ) {
-		// aveDipDirectionRad = Faults.dipDirectionRad(trace);
-		// } else {
-		// aveDipDirectionRad = dipDir * GeoTools.TO_RAD;
-		// }
 		double lowerDepth = depth + width * Math.sin(dipRad);
 
 		for (Location traceLoc : trace) {
-
-			// // TODO ignoring seismogenic depth for now
-			// double vDistance = upperSeisDepth - traceLoc.depth();
-			// double hDistance = vDistance / Math.tan(dipRad);
-			//
-			// // LocationVector dir = new LocationVector(aveDipDirection,
-			// hDistance, vDistance);
-			// LocationVector dir = LocationVector.create(dipDirRad, hDistance,
-			// vDistance);
-			// Location topLoc = Locations.location(traceLoc, dir);
-			// topLocs.add(topLoc);
 
 			Location topLoc = Location.create(traceLoc.lat(), traceLoc.lon(), depth);
 			topLocs.add(topLoc);

--- a/src/org/opensha2/eq/fault/surface/DefaultGriddedSurface.java
+++ b/src/org/opensha2/eq/fault/surface/DefaultGriddedSurface.java
@@ -93,6 +93,10 @@ public class DefaultGriddedSurface extends AbstractGriddedSurface {
 	 * want to recompute it internally.
 	 * 
 	 * TODO single-use builder
+	 * 
+	 * TODO right-hand-rule
+	 * 
+	 * TODO should surface only be a single row if width < dipSpacing/2
 	 */
 	@SuppressWarnings("javadoc")
 	public static class Builder {
@@ -298,7 +302,7 @@ public class DefaultGriddedSurface extends AbstractGriddedSurface {
 			// out but perhaps will have to be reintroduced
 			Location topLocation = Location.create(traceLocation.lat(), traceLocation.lon(), depth);
 
-			set(0, ith_col, Location.copyOf(topLocation));
+			set(0, ith_col, topLocation);
 			// if( D ) System.out.println("   (x,y) topLocation = (0, " +
 			// ith_col + ") " + topLocation );
 
@@ -321,7 +325,7 @@ public class DefaultGriddedSurface extends AbstractGriddedSurface {
 				dir = LocationVector.create(dipDirRad, hDistance, vDistance);
 
 				Location depthLocation = Locations.location(topLocation, dir);
-				set(ith_row, ith_col, Location.copyOf(depthLocation));
+				set(ith_row, ith_col, depthLocation);
 				// if( D ) System.out.println("    (x,y) depthLocation = (" +
 				// ith_row + ", " + ith_col + ") " + depthLocation );
 
@@ -342,7 +346,7 @@ public class DefaultGriddedSurface extends AbstractGriddedSurface {
 	public void create(LocationList trace, double dip, double width, double spacing) {
 		double dipRad = dip * TO_RAD;
 		double dipDirRad = Faults.dipDirectionRad(trace);
-		LocationList resampled = LocationList.resampledFrom(trace, spacing);
+		LocationList resampled = trace.resample(spacing);
 		int nCol = resampled.size();
 		// strike-parallel row count, NOT including trace
 		int nRow = DoubleMath.roundToInt(width / spacing, HALF_UP);

--- a/src/org/opensha2/eq/fault/surface/GriddedFaultSurface.java
+++ b/src/org/opensha2/eq/fault/surface/GriddedFaultSurface.java
@@ -1,0 +1,167 @@
+package org.opensha2.eq.fault.surface;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static org.opensha2.data.Data.checkInRange;
+import static org.opensha2.eq.fault.Faults.validateDepth;
+import static org.opensha2.eq.fault.Faults.validateDip;
+import static org.opensha2.eq.fault.Faults.validateInterfaceWidth;
+import static org.opensha2.eq.fault.Faults.validateStrike;
+import static org.opensha2.eq.fault.Faults.validateTrace;
+import static org.opensha2.geo.GeoTools.TO_RAD;
+
+import org.opensha2.eq.fault.Faults;
+import org.opensha2.geo.Location;
+import org.opensha2.geo.LocationGrid;
+import org.opensha2.geo.LocationList;
+
+import com.google.common.collect.ArrayTable;
+import com.google.common.collect.Range;
+import com.google.common.primitives.Doubles;
+
+/**
+ * Add comments here
+ *
+ * @author Peter Powers
+ */
+public class GriddedFaultSurface {
+
+	private final LocationGrid grid;
+
+	// TODO not sure these are really needed once surface is constructed
+	private final double strikeSpacing;
+	private final double dipSpacing;
+
+	private GriddedFaultSurface(LocationGrid grid,
+			double strikeSpacing,
+			double dipSpacing) {
+
+		this.grid = grid;
+		this.strikeSpacing = strikeSpacing;
+		this.dipSpacing = dipSpacing;
+	}
+
+	// public static GriddedFaultSurface create()
+
+	/*
+	 * Document that width, whether computed from top-bottom or assigned, is
+	 * always then applied in the dip direction, either supplied or computed
+	 * from trace.
+	 */
+
+	public Builder builder() {
+		return new Builder();
+	}
+
+	/*
+	 * TODO document builder which will almost certainly be part of a public API
+	 * 
+	 * TODO doc trace assumed to be at depth=0?
+	 * 
+	 * TODO do trace depths all need to be the same; condidtion used to be
+	 * imposed in assertValidState
+	 * 
+	 * TODO surface is initialized with a dip direction in radians; this may be
+	 * normal to Faults.strike(trace), but may not be; in any event, we do not
+	 * want to recompute it internally.
+	 * 
+	 * TODO single-use builder
+	 * 
+	 * TODO right-hand-rule
+	 * 
+	 * TODO should surface only be a single row if width < dipSpacing/2
+	 */
+	public static class Builder {
+
+		private static final Range<Double> SPACING_RANGE = Range.closed(0.01, 20.0);
+		private static final String ID = "GriddedFaultSurface.Builder";
+
+		private boolean built = false;
+
+		// required
+		private LocationList trace;
+		private Double dipRad;
+		private Double depth;
+
+		// conditional (either but not both)
+		private Double width;
+		private Double lowerDepth;
+
+		// optional - dipDir may not necessarily be normal to strike
+		private Double dipDirRad;
+
+		// optional with defualts
+		private double strikeSpacing = 1.0;
+		private double dipSpacing = 1.0;
+
+		private Builder() {}
+
+		public Builder trace(LocationList trace) {
+			this.trace = validateTrace(trace);
+			return this;
+		}
+
+		public Builder dip(double dip) {
+			this.dipRad = validateDip(dip) * TO_RAD;
+			return this;
+		}
+
+		public Builder dipDir(double dipDir) {
+			this.dipDirRad = validateStrike(dipDir) * TO_RAD;
+			return this;
+		}
+
+		public Builder depth(double depth) {
+			this.depth = validateDepth(depth);
+			return this;
+		}
+
+		public Builder lowerDepth(double lowerDepth) {
+			checkState(width == null, "Either lower depth or width may be set, but not both");
+			this.lowerDepth = validateDepth(lowerDepth);
+			return this;
+		}
+
+		public Builder width(double width) {
+			checkState(lowerDepth == null, "Either width or lower depth may be set, but not both");
+			// we don't know what the surface may be used to represent
+			// so we validate against the largest (interface) values
+			this.width = validateInterfaceWidth(width);
+			return this;
+		}
+
+		public Builder spacing(double spacing) {
+			return spacing(spacing, spacing);
+		}
+
+		public Builder spacing(double strike, double dip) {
+			this.strikeSpacing = checkInRange(SPACING_RANGE, "Strike Spacing", strike);
+			this.dipSpacing = checkInRange(SPACING_RANGE, "Dip Spacing", dip);
+			return this;
+		}
+
+		private void validateState(String id) {
+			checkState(!built, "This %s instance as already been used", id);
+			checkState(trace != null, "%s trace not set", id);
+			checkState(dipRad != null, "%s dip not set", id);
+			checkState(depth != null, "%s depth not set", id);
+
+			checkState((width != null) ^ (lowerDepth != null), "%s width or lowerDepth not set", id);
+			if (lowerDepth != null && lowerDepth <= depth) {
+				throw new IllegalStateException("Lower depth is above upper depth");
+			}
+			built = true;
+		}
+
+		public DefaultGriddedSurface build() {
+			validateState(ID);
+			if (dipDirRad == null) dipDirRad = Faults.dipDirectionRad(trace);
+			if (width == null) width = (lowerDepth - depth) / Math.sin(dipRad);
+			return null;
+			// new DefaultGriddedSurface(trace, dipRad, dipDirRad, depth, width,
+			// strikeSpacing, dipSpacing);
+		}
+
+	}
+}

--- a/src/org/opensha2/eq/fault/surface/GriddedSubsetSurface.java
+++ b/src/org/opensha2/eq/fault/surface/GriddedSubsetSurface.java
@@ -185,7 +185,7 @@ public class GriddedSubsetSurface extends ContainerSubset2D<Location> implements
 				 */
 	public LocationList getPerimeter() {
 		LocationList topTr = getRow(0);
-		LocationList botTr = LocationList.reverseOf(getRow(getNumRows() - 1));
+		LocationList botTr = LocationList.create(getRow(getNumRows() - 1)).reverse();
 		Iterable<Location> locs = Iterables.concat(topTr, botTr,
 			Lists.newArrayList(topTr.get(0)));
 		return LocationList.create(locs);

--- a/src/org/opensha2/eq/model/AreaSource.java
+++ b/src/org/opensha2/eq/model/AreaSource.java
@@ -31,6 +31,7 @@ import org.opensha2.eq.model.PointSource.DepthModel;
 import org.opensha2.geo.GriddedRegion;
 import org.opensha2.geo.Location;
 import org.opensha2.geo.LocationList;
+import org.opensha2.geo.Locations;
 import org.opensha2.geo.Regions;
 import org.opensha2.mfd.IncrementalMfd;
 import org.opensha2.mfd.Mfds;
@@ -150,7 +151,8 @@ public class AreaSource implements Source {
 	 * @param loc Location of interest
 	 */
 	public Iterable<Rupture> iterableForLocation(Location loc) {
-		double distance = sourceGrids.get(0).border().minDistToLine(loc);
+		LocationList border = sourceGrids.get(0).border();
+		double distance = Locations.minDistanceToLine(loc, border);
 		int gridIndex = gridScaling.indexForDistance(distance);
 		GriddedRegion sourceGrid = sourceGrids.get(gridIndex);
 		return sourceGridIterable(sourceGrid);

--- a/src/org/opensha2/eq/model/AreaSourceSet.java
+++ b/src/org/opensha2/eq/model/AreaSourceSet.java
@@ -9,6 +9,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.opensha2.geo.Location;
+import org.opensha2.geo.Locations;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
@@ -48,7 +49,7 @@ public class AreaSourceSet extends AbstractSourceSet<AreaSource> {
 	@Override public Predicate<AreaSource> distanceFilter(final Location loc, final double distance) {
 		return new Predicate<AreaSource>() {
 			@Override public boolean apply(AreaSource source) {
-				return source.border().minDistToLocation(loc) <= distance;
+				return Locations.minDistanceToLocations(loc, source.border()) <= distance;
 			}
 		};
 	}

--- a/src/org/opensha2/eq/model/Distance.java
+++ b/src/org/opensha2/eq/model/Distance.java
@@ -209,14 +209,14 @@ public final class Distance {
 			LocationList region = LocationList.builder()
 					.add(p1)
 					.add(p2)
-					.add(trace)
+					.addAll(trace)
 					.add(p3)
 					.add(p4)
 					.build();
 			
 			LocationList extendedTrace = LocationList.builder()
 					.add(p2)
-					.add(trace)
+					.addAll(trace)
 					.add(p3)
 					.build();
 			// @formatter:on
@@ -312,7 +312,9 @@ public final class Distance {
 				}
 				boolean isInside = polygon.contains(siteLoc);
 
-				double distToExtendedTrace = LocationList.create(extendedTrace).minDistToLine(siteLoc);
+				double distToExtendedTrace = Locations.minDistanceToLine(
+					siteLoc,
+					LocationList.create(extendedTrace));
 
 				if(isInside || distToExtendedTrace == 0.0) { // zero values are always on the hanging wall
 					return distToExtendedTrace;
@@ -336,7 +338,7 @@ public final class Distance {
 		// endpoints. If the closest segment distance is less than both endpoint
 		// distances, use that segment as a line to compute rX, otherwise use
 		// endpoints of the trace as a line to compute rX
-		int minIndex = trace.minDistIndex(loc);
+		int minIndex = Locations.minDistanceIndex(loc, trace);
 		double rSeg = distanceToSegmentFast(trace.get(minIndex),
 			trace.get(minIndex + 1), loc);
 		double rFirst = horzDistanceFast(trace.first(), loc);

--- a/src/org/opensha2/geo/Location.java
+++ b/src/org/opensha2/geo/Location.java
@@ -54,12 +54,6 @@ public final class Location implements Comparable<Location> {
 		this.depth = validateDepth(depth);
 	}
 
-	private Location(Location loc) {
-		this.lat = loc.lat;
-		this.lon = loc.lon;
-		this.depth = loc.depth;
-	}
-
 	/**
 	 * Create a new {@code Location} with the supplied latitude and longitude
 	 * and a depth of 0 km.
@@ -85,15 +79,6 @@ public final class Location implements Comparable<Location> {
 	 */
 	public static Location create(double lat, double lon, double depth) {
 		return new Location(lat, lon, depth);
-	}
-
-	/**
-	 * Create a new {@code Location} that is identircal to the one supplied.
-	 * @param loc {@code Location} to copy
-	 */
-	@Deprecated
-	public static Location copyOf(Location loc) {
-		return new Location(loc);
 	}
 
 	/**

--- a/src/org/opensha2/geo/Location.java
+++ b/src/org/opensha2/geo/Location.java
@@ -36,14 +36,6 @@ import com.google.common.primitives.Doubles;
  */
 public final class Location implements Comparable<Location> {
 
-	/**
-	 * Format {@code String("%.5f")} used for presentation of {@code Location}
-	 * data. For use with {@link String#format(String, Object...)}.
-	 */
-	public static final String FORMAT = "%.5f";
-
-	private static final String TO_STR_FMT = FORMAT + "," + FORMAT + "," + FORMAT;
-
 	private final double lat;
 	private final double lon;
 	private final double depth;
@@ -64,7 +56,7 @@ public final class Location implements Comparable<Location> {
 	 * @see GeoTools
 	 */
 	public static Location create(double lat, double lon) {
-		return new Location(lat, lon, 0);
+		return create(lat, lon, 0);
 	}
 
 	/**
@@ -129,12 +121,14 @@ public final class Location implements Comparable<Location> {
 		return lon;
 	}
 
+	private static final String FORMAT = "%.5f,%.5f,%.5f";
+
 	/**
-	 * Returns a KML compatible tuple: 'lon,lat,depth' (no spaces).
+	 * Return a KML compatible tuple: 'lon,lat,depth' (no spaces).
 	 * @see #fromString(String)
 	 */
 	@Override public String toString() {
-		return String.format(TO_STR_FMT, lon(), lat(), depth());
+		return String.format(FORMAT, lon(), lat(), depth());
 	}
 
 	@Override public boolean equals(Object obj) {

--- a/src/org/opensha2/geo/Location.java
+++ b/src/org/opensha2/geo/Location.java
@@ -81,7 +81,11 @@ public final class Location implements Comparable<Location> {
 	 * 
 	 * @param s string to parse
 	 * @throws NumberFormatException if {@code s} is unparseable
+	 * @throws IndexOutOfBoundsException if {@code s} contains fewer than 3
+	 *         comma-separated values; any additional values in the suppied
+	 *         string are ignored
 	 * @see #toString()
+	 * @see #stringConverter()
 	 */
 	public static Location fromString(String s) {
 		return StringConverter.INSTANCE.reverse().convert(s);
@@ -125,6 +129,7 @@ public final class Location implements Comparable<Location> {
 	/**
 	 * Return a KML compatible tuple: 'lon,lat,depth' (no spaces).
 	 * @see #fromString(String)
+	 * @see #stringConverter()
 	 */
 	@Override public String toString() {
 		return stringConverter().convert(this);
@@ -133,13 +138,19 @@ public final class Location implements Comparable<Location> {
 	/**
 	 * Return a {@link Converter} that converts between {@code Location}s and
 	 * {@code String}s.
+	 * 
+	 * <p>Calls to {@code converter.reverse().convert(String)} will throw a
+	 * {@code NumberFormatException} if the values in the supplied string are
+	 * unparseable; or an {@code IndexOutOfBoundsException} if the supplied
+	 * string contains fewer than 3 comma-separated values; any additional
+	 * values in the suppied string are ignored.
 	 */
 	public static Converter<Location, String> stringConverter() {
 		return StringConverter.INSTANCE;
 	}
 
 	private static final class StringConverter extends Converter<Location, String> {
-		
+
 		static final StringConverter INSTANCE = new StringConverter();
 		static final String FORMAT = "%.5f,%.5f,%.5f";
 

--- a/src/org/opensha2/geo/Location.java
+++ b/src/org/opensha2/geo/Location.java
@@ -20,32 +20,30 @@ import com.google.common.primitives.Doubles;
  * A {@code Location} represents a point with reference to the earth's
  * ellipsoid. It is expressed in terms of latitude, longitude, and depth. As in
  * seismology, the convention adopted in here is for depth to be positive-down,
- * always. All utility methods in this package assume this to be the case.
- * {@code Location}s may be defined using longitude values in the range:
- * [-180°, 360°]. {@code Location} instances are immutable.
+ * always. Locations may be defined using longitude values in the range: [-180°,
+ * 360°]. Location instances are immutable.
  * 
  * <p>Note that although static factory methods take arguments in the order:
- * [lat, lon, depth], {@code String} representations of a {@code Location} are
- * in the order: [lon, lat, depth], consistent with KML, GeoJSON, and other
- * digital coordinate formats that match standard plotting coordinate order: [x,
- * y, z].</p>
+ * [lat, lon, depth], {@code String} representations of a location are in the
+ * order: [lon, lat, depth], consistent with KML, GeoJSON, and other digital
+ * coordinate formats that match standard plotting coordinate order: [x, y, z].
  * 
- * <p>For computational cenvenience, latitude and longitude values are converted
+ * <p>For computational convenience, latitude and longitude values are converted
  * and stored internally in radians. Special {@code get***Rad()} methods are
- * provided to access this native format.</p>
+ * provided to access this native format.
  * 
  * @author Peter Powers
  */
 public final class Location implements Comparable<Location> {
 
 	/**
-	 * Format {@code String("%.5f")} used for presentation of {@code Location} data.
-	 * For use with {@link String#format(String, Object...)}.
+	 * Format {@code String("%.5f")} used for presentation of {@code Location}
+	 * data. For use with {@link String#format(String, Object...)}.
 	 */
 	public static final String FORMAT = "%.5f";
-	
+
 	private static final String TO_STR_FMT = FORMAT + "," + FORMAT + "," + FORMAT;
-	
+
 	private final double lat;
 	private final double lon;
 	private final double depth;
@@ -55,7 +53,7 @@ public final class Location implements Comparable<Location> {
 		this.lon = validateLon(lon) * TO_RAD;
 		this.depth = validateDepth(depth);
 	}
-	
+
 	private Location(Location loc) {
 		this.lat = loc.lat;
 		this.lon = loc.lon;
@@ -63,12 +61,11 @@ public final class Location implements Comparable<Location> {
 	}
 
 	/**
-	 * Creates a new {@code Location} with the supplied latitude and
-	 * longitude and a depth of 0 km.
+	 * Create a new {@code Location} with the supplied latitude and longitude
+	 * and a depth of 0 km.
 	 * 
 	 * @param lat latitude in decimal degrees
 	 * @param lon longitude in decimal degrees
-	 * @return a new {@code Location}
 	 * @throws IllegalArgumentException if any supplied values are out of range
 	 * @see GeoTools
 	 */
@@ -77,13 +74,12 @@ public final class Location implements Comparable<Location> {
 	}
 
 	/**
-	 * Creates a new {@code Location} with the supplied latitude, longitude,
-	 * and depth.
+	 * Create a new {@code Location} with the supplied latitude, longitude, and
+	 * depth.
 	 * 
 	 * @param lat latitude in decimal degrees
 	 * @param lon longitude in decimal degrees
 	 * @param depth in km (positive down)
-	 * @return a new {@code Location}
 	 * @throws IllegalArgumentException if any supplied values are out of range
 	 * @see GeoTools
 	 */
@@ -92,21 +88,21 @@ public final class Location implements Comparable<Location> {
 	}
 
 	/**
-	 * Creates a new {@code Location} that is identircal to the one supplied.
+	 * Create a new {@code Location} that is identircal to the one supplied.
 	 * @param loc {@code Location} to copy
-	 * @return an exact copy of the supplied {@code Location}
 	 */
+	@Deprecated
 	public static Location copyOf(Location loc) {
 		return new Location(loc);
 	}
-	
+
 	/**
-	 * Generates a new {@code Location} by parsing the supplied {@code String}.
+	 * Generate a new {@code Location} by parsing the supplied {@code String}.
 	 * Method is the complement of {@link #toString()} and is intended for use
 	 * with the result of that method.
-	 * @param s to parse
-	 * @return a new Location
-	 * @throws NumberFormatException if s is unparseable
+	 * 
+	 * @param s string to parse
+	 * @throws NumberFormatException if {@code s} is unparseable
 	 * @see #toString()
 	 */
 	public static Location fromString(String s) {
@@ -114,40 +110,35 @@ public final class Location implements Comparable<Location> {
 	}
 
 	/**
-	 * Returns the depth of this {@code Location}.
-	 * @return the {@code Location} depth in km
+	 * Returns the depth of this {@code Location} in km.
 	 */
 	public double depth() {
 		return depth;
 	}
 
 	/**
-	 * Returns the latitude of this {@code Location}.
-	 * @return the {@code Location} latitude in decimal degrees
+	 * The latitude of this {@code Location} in decimal degrees.
 	 */
 	public double lat() {
 		return lat * TO_DEG;
 	}
 
 	/**
-	 * Returns the longitude of this {@code Location}.
-	 * @return the {@code Location} longitude in decimal degrees
+	 * The longitude of this {@code Location} in decimal degrees.
 	 */
 	public double lon() {
 		return lon * TO_DEG;
 	}
 
 	/**
-	 * Returns the latitude of this {@code Location} in radians.
-	 * @return the {@code Location} latitude in radians
+	 * The latitude of this {@code Location} in radians.
 	 */
 	public double latRad() {
 		return lat;
 	}
 
 	/**
-	 * Returns the longitude of this {@code Location} in radians.
-	 * @return the {@code Location} longitude in radians
+	 * The longitude of this {@code Location} in radians.
 	 */
 	public double lonRad() {
 		return lon;
@@ -157,13 +148,11 @@ public final class Location implements Comparable<Location> {
 	 * Returns a KML compatible tuple: 'lon,lat,depth' (no spaces).
 	 * @see #fromString(String)
 	 */
-	@Override
-	public String toString() {
+	@Override public String toString() {
 		return String.format(TO_STR_FMT, lon(), lat(), depth());
 	}
 
-	@Override
-	public boolean equals(Object obj) {
+	@Override public boolean equals(Object obj) {
 		if (this == obj) return true;
 		if (!(obj instanceof Location)) return false;
 		Location loc = (Location) obj;
@@ -189,27 +178,23 @@ public final class Location implements Comparable<Location> {
 	}
 
 	/**
-	 * Compares this {@code Location} to another and sorts first by latitude,
-	 * then by longitude. When sorting a list of randomized but evenly spaced
-	 * grid of {@code Location}s, the resultant ordering will be left to right
-	 * across rows of uniform latitude, ascending to the leftmost next higher
-	 * latitude at the end of each row (left-to-right, bottom-to-top).
+	 * Compare this {@code Location} to another and sort first by latitude, then
+	 * by longitude. When sorting a list of {@code Location}s, the resultant
+	 * ordering is left-to-right, bottom-to-top.
 	 * 
 	 * @param loc {@code Location} to compare {@code this} to
 	 * @return a negative integer, zero, or a positive integer if this
 	 *         {@code Location} is less than, equal to, or greater than the
 	 *         specified {@code Location}.
 	 */
-	@Override
-	public int compareTo(Location loc) {
+	@Override public int compareTo(Location loc) {
 		double d = (lat == loc.lat) ? lon - loc.lon : lat - loc.lat;
 		return (d != 0) ? (d < 0) ? -1 : 1 : 0;
 	}
 
 	/**
-	 * Returns a {@link Function} that can be used to convert {@code String}s
-	 * to {@code Location}s. 
-	 * @return a {@code String} to {@code Location} conversion function
+	 * Return a {@link Function} that can be used to convert {@code String}s to
+	 * {@code Location}s.
 	 */
 	public static Function<String, Location> fromStringFunction() {
 		return FromStringFunction.INSTANCE;
@@ -219,8 +204,7 @@ public final class Location implements Comparable<Location> {
 	private static enum FromStringFunction implements
 			Function<String, Location> {
 		INSTANCE;
-		@Override
-		public Location apply(String s) {
+		@Override public Location apply(String s) {
 			Iterator<Double> it = FluentIterable
 				.from(Parsing.split(checkNotNull(s), Delimiter.COMMA))
 				.transform(Doubles.stringConverter()).iterator();

--- a/src/org/opensha2/geo/LocationGrid.java
+++ b/src/org/opensha2/geo/LocationGrid.java
@@ -1,0 +1,432 @@
+package org.opensha2.geo;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkElementIndex;
+import static com.google.common.base.Preconditions.checkPositionIndex;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.*;
+import static org.opensha2.util.TextUtils.NEWLINE;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import com.google.common.collect.ArrayTable;
+import com.google.common.collect.ContiguousSet;
+import com.google.common.collect.DiscreteDomain;
+import com.google.common.collect.Range;
+
+/**
+ * An immutable, tabular grid of locations that supplies row and column data as
+ * {@link LocationList}s.
+ * 
+ * <p>Internally, the grid is backed by a Guava {@link ArrayTable}.
+ *
+ * @author Peter Powers
+ */
+public final class LocationGrid implements Iterable<Location> {
+
+	private final ArrayTable<Integer, Integer, Location> grid;
+
+	// starts are inclusive, ends are exclusive
+	private final int rowStart;
+	private final int rowWidth;
+	private final int rowEnd;
+	private final int columnStart;
+	private final int columnWidth;
+	private final int columnEnd;
+
+	// true if entire grid is being used
+	private final boolean master;
+
+	private LocationGrid(
+			ArrayTable<Integer, Integer, Location> grid,
+			int rowStart,
+			int rowWidth,
+			int columnStart,
+			int columnWidth) {
+
+		this.grid = grid;
+
+		this.rowStart = rowStart;
+		this.rowWidth = rowWidth;
+		this.rowEnd = rowStart + rowWidth;
+
+		this.columnStart = columnStart;
+		this.columnWidth = columnWidth;
+		this.columnEnd = columnStart + columnWidth;
+
+		this.master = rowStart == 0 && rowWidth == grid.rowKeyList().size() &&
+			columnStart == 0 && columnWidth == grid.columnKeyList().size();
+	}
+
+	/**
+	 * Return the number of {@code Location}s in this grid.
+	 */
+	public int size() {
+		return rowWidth * columnWidth;
+	}
+
+	/**
+	 * Return the number of rows in this grid.
+	 */
+	public int rows() {
+		return rowWidth;
+	}
+
+	/**
+	 * Return the row at index.
+	 * @param index of the row to retrieve
+	 * @throws IndexOutOfBoundsException if {@code index < 0 || index >= rows()}
+	 */
+	public LocationList row(int index) {
+		return new Row(rowStart + checkElementIndex(index, rows()));
+	}
+
+	/**
+	 * Return the first row.
+	 */
+	public LocationList firstRow() {
+		return row(0);
+	}
+
+	/**
+	 * Return the last row.
+	 */
+	public LocationList lastRow() {
+		return row(rows() - 1);
+	}
+
+	/**
+	 * Return the number of columns in this grid.
+	 */
+	public int columns() {
+		return columnWidth;
+	}
+
+	/**
+	 * Return the column at index.
+	 * @param index of the column to retrieve
+	 * @throws IndexOutOfBoundsException if
+	 *         {@code index < 0 || index >= columns()}
+	 */
+	public LocationList column(int index) {
+		return new Column(columnStart + checkElementIndex(index, columns()));
+	}
+
+	/**
+	 * Return the first column.
+	 */
+	public LocationList firstColumn() {
+		return column(0);
+	}
+
+	/**
+	 * Return the last column.
+	 */
+	public LocationList lastColumn() {
+		return column(columns() - 1);
+	}
+
+	/**
+	 * Return a new grid that is a window into this one. The specified window
+	 * dimensions must be less than or equal to the dimensions of this grid.
+	 * 
+	 * @param rowStart first row of window
+	 * @param rowWidth number of rows in the window
+	 * @param columnStart first column of window
+	 * @param columnWidth
+	 * @return
+	 */
+	public LocationGrid window(int rowStart, int rowWidth, int columnStart, int columnWidth) {
+		checkElementIndex(rowStart, this.rowWidth);
+		checkPositionIndex(rowStart + rowWidth, this.rowWidth);
+		checkElementIndex(columnStart, this.columnWidth);
+		checkPositionIndex(columnStart + columnWidth, this.columnWidth);
+		return new LocationGrid(
+			this.grid,
+			this.rowStart + rowStart,
+			rowWidth,
+			this.columnStart + columnStart,
+			columnWidth);
+	}
+
+	/**
+	 * Return the parent grid. Method returns itself unless it was created using
+	 * one or more calls to {@link #window(int, int, int, int)}. In this case, a
+	 * grid equivalent to this grid's greatest ancestor is returned.
+	 */
+	public LocationGrid parent() {
+		return master ? this : new LocationGrid(
+			grid,
+			0, grid.rowKeyList().size(),
+			0, grid.columnKeyList().size());
+	}
+
+	@Override public String toString() {
+		StringBuilder sb = new StringBuilder("LocationGrid [")
+			.append(rowWidth).append(" x ")
+			.append(columnWidth).append("]")
+			.append(" window=").append(!master);
+		if (!master) {
+			sb.append(" [parent ")
+				.append(grid.rowKeyList().size()).append("r x ")
+				.append(grid.columnKeyList().size()).append("c]");
+		}
+		sb.append(NEWLINE);
+		LocationList firstRow = firstRow();
+		int lastColumnIndex = rowWidth - 1;
+		int lastRowIndex = columnWidth - 1;
+		appendCorner(sb, 0, 0, firstRow.first());
+		appendCorner(sb, 0, lastColumnIndex, firstRow.last());
+		LocationList lastRow = lastRow();
+		appendCorner(sb, lastRowIndex, 0, lastRow.first());
+		appendCorner(sb, lastRowIndex, lastColumnIndex, lastRow.last());
+		if (size() < 1024) {
+			sb.append("Locations:").append(NEWLINE);
+			for (int i = 0; i < rows(); i++) {
+				for (int j = 0; j < columns(); j++) {
+					appendLocation(sb, i, j, grid.at(i, j));
+				}
+				sb.append(NEWLINE);
+			}
+		}
+		return sb.toString();
+	}
+
+	private static void appendCorner(StringBuilder builder, int row, int column, Location loc) {
+		builder.append("Corner: ");
+		appendLocation(builder, row, column, loc);
+	}
+
+	private static void appendLocation(StringBuilder builder, int row, int column, Location loc) {
+		builder.append(padStart(Integer.toString(row), 5, ' '))
+			.append(padStart(Integer.toString(column), 5, ' '))
+			.append("    ").append(loc)
+			.append(NEWLINE);
+	}
+
+	@Override public Iterator<Location> iterator() {
+		return new Iterator<Location>() {
+
+			private int rowIndex = rowStart;
+			private int columnIndex = columnStart;
+
+			@Override public boolean hasNext() {
+				return columnIndex < columnEnd && rowIndex < rowEnd;
+			}
+
+			@Override public Location next() {
+				Location loc = grid.at(rowIndex, columnIndex++);
+				if (columnIndex == columnEnd) rowIndex++;
+				return loc;
+			}
+
+			@Override public void remove() {
+				throw new UnsupportedOperationException();
+			}
+		};
+	}
+
+	private class Row extends LocationList {
+
+		private final int rowIndex;
+
+		private Row(int rowIndex) {
+			this.rowIndex = rowIndex;
+		}
+
+		@Override public int size() {
+			return grid.columnKeyList().size();
+		}
+
+		@Override public Location get(int index) {
+			return grid.at(rowIndex, index);
+		}
+
+		@Override public Iterator<Location> iterator() {
+			return new Iterator<Location>() {
+				private int columnIndex;
+
+				@Override public boolean hasNext() {
+					return columnIndex < columnEnd;
+				}
+
+				@Override public Location next() {
+					return grid.at(rowIndex, columnIndex++);
+				}
+
+				@Override public void remove() {
+					throw new UnsupportedOperationException();
+				}
+			};
+		}
+	}
+
+	private class Column extends LocationList {
+
+		private final int columnIndex;
+
+		private Column(int columnIndex) {
+			this.columnIndex = columnIndex;
+		}
+
+		@Override public int size() {
+			return grid.rowKeyList().size();
+		}
+
+		@Override public Location get(int index) {
+			return grid.at(index, columnIndex);
+		}
+
+		@Override public Iterator<Location> iterator() {
+			return new Iterator<Location>() {
+				private int rowIndex;
+
+				@Override public boolean hasNext() {
+					return rowIndex < rowEnd;
+				}
+
+				@Override public Location next() {
+					return grid.at(rowIndex++, columnIndex);
+				}
+
+				@Override public void remove() {
+					throw new UnsupportedOperationException();
+				}
+			};
+		}
+	}
+
+	/**
+	 * Return a new builder.
+	 * 
+	 * @param rows expected number of rows
+	 * @param columns expected number of columns
+	 */
+	public static Builder builder(int rows, int columns) {
+		return new Builder(rows, columns);
+	}
+
+	/**
+	 * A single-use builder of {@code LocationGrid}s. Use
+	 * {@link LocationGrid#builder(int, int)} to create new builder instances.
+	 */
+	public static class Builder {
+
+		private final ArrayTable<Integer, Integer, Location> grid;
+		private boolean built = false;
+
+		private Builder(int rows, int columns) {
+			grid = ArrayTable.create(
+				ContiguousSet.create(Range.closedOpen(0, rows), DiscreteDomain.integers()),
+				ContiguousSet.create(Range.closedOpen(0, columns), DiscreteDomain.integers()));
+		};
+
+		/**
+		 * Set the Location at the specified {@code row} and {@code column}
+		 * indices.
+		 * 
+		 * @param row index of location to set
+		 * @param column index of location to set
+		 * @param loc to set
+		 * @return this {@code Builder}
+		 */
+		public Builder set(int row, int column, Location loc) {
+			grid.set(row, column, loc);
+			return this;
+		}
+
+		/**
+		 * Fill a row with the specified {@code Location}s.
+		 * 
+		 * @param index of row to fill
+		 * @param locs to fill row with
+		 * @return this {@code Builder}
+		 */
+		public Builder fillRow(int index, LocationList locs) {
+			checkArgument(locs.size() == grid.columnKeyList().size());
+			int column = 0;
+			for (Location loc : locs) {
+				grid.set(index, column++, loc);
+			}
+			return this;
+		}
+
+		/**
+		 * Fill a row with the specified {@code Location}s.
+		 * 
+		 * @param index of column to fill
+		 * @param locs to fill column with
+		 * @return this {@code Builder}
+		 */
+		public Builder fillColumn(int index, LocationList locs) {
+			checkArgument(locs.size() == grid.rowKeyList().size());
+			int row = 0;
+			for (Location loc : locs) {
+				grid.set(row++, index, loc);
+			}
+			return this;
+		}
+
+		/**
+		 * Return a newly created {@code LocationGrid}.
+		 */
+		public LocationGrid build() {
+			checkState(!grid.containsValue(null), "Some Locations have not been set");
+			checkState(!built, "This builder has already been used");
+			return new LocationGrid(
+				grid,
+				0, grid.rowKeyList().size(),
+				0, grid.columnKeyList().size());
+		}
+	}
+
+	// TODO clean
+	public static void main(String[] args) {
+
+		Set<Integer> strikeIndices = ContiguousSet.create(
+			Range.closedOpen(0, 9),
+			DiscreteDomain.integers());
+
+		Set<Integer> dipIndices = ContiguousSet.create(
+			Range.closedOpen(0, 4),
+			DiscreteDomain.integers());
+
+		ArrayTable<Integer, Integer, Location> t = ArrayTable.create(dipIndices, strikeIndices);
+
+		for (int dipIndex : dipIndices) {
+			for (int strikeIndex : strikeIndices) {
+				Location loc = Location.create(
+					34.0 + 0.2 * strikeIndex,
+					-117.4 + 0.1 * dipIndex);
+				t.set(dipIndex, strikeIndex, loc);
+			}
+		}
+
+		LocationGrid grid2 = new LocationGrid(t, 0, dipIndices.size(), 0, strikeIndices.size());
+		System.out.println(grid2);
+
+		int rows = 4;
+		int cols = 9;
+		Builder b = builder(4, 9);
+		
+		for (int i = 0; i<rows; i++) {
+			for (int j = 0; j<cols; j++) {
+				Location loc = Location.create(
+					34.0 + 0.2 * j,
+					-117.4 + 0.1 * i);
+				b.set(i, j, loc);
+			}
+		}
+		System.out.println(b.grid);
+		LocationGrid grid = b.build();
+		System.out.println(grid.grid.rowKeyList());
+		System.out.println(grid.grid.columnKeyList());
+		System.out.println(grid);
+
+		// System.out.println(grid.lastColumn());
+		// Iterator<Location> it = grid.firstRow().iterator();
+		// System.out.println(it);
+		// TODO test itertator.remove()
+	}
+}

--- a/src/org/opensha2/geo/LocationList.java
+++ b/src/org/opensha2/geo/LocationList.java
@@ -6,26 +6,37 @@ import static com.google.common.base.Preconditions.checkState;
 import static org.opensha2.util.TextUtils.NEWLINE;
 
 import java.util.Iterator;
+import java.util.List;
 
 import org.opensha2.util.Parsing;
 import org.opensha2.util.Parsing.Delimiter;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import com.google.common.primitives.Doubles;
 
 /**
- * An ordered collection of {@link Location}s.
+ * An immutable, ordered collection of {@link Location}s.
  * 
  * <p>A {@code LocationList} must contain at least 1 {@code Location} and does
- * not permit any location to be {@code null}. {@code LocationList} instances
- * are immutable and calls to {@code remove()} when iterating will throw an
- * {@code UnsupportedOperationException}.
+ * not permit {@code null} elements. {@code LocationList} instances are
+ * immutable and calls to {@code remove()} when iterating will throw an
+ * {@code UnsupportedOperationException}. A variety of methods exist to simplify
+ * the creation of new lists via modification (e.g. {@link #resample(double)} ,
+ * {@link #reverse()}, and {@link #translate(LocationVector)}.
  * 
- * <p>Consider using a {@link LocationList.Builder} (via a call to
- * {@link #builder()}) if list is being compiled from numerous {@code Location}s
- * that are not known in advance.
+ * <p>Consider using a {@link LocationList.Builder} (via {@link #builder()}) if
+ * a list is being compiled from numerous {@code Location}s that are not known
+ * in advance.
+ * 
+ * <p><b>Note:</b> Although this class is not final, it cannot be subclassed
+ * outside its package as it has no public or protected constructors. Thus,
+ * instances of this type are guaranteed to be immutable.
  * 
  * @author Peter Powers
  */
@@ -39,84 +50,46 @@ public abstract class LocationList implements Iterable<Location> {
 	 * @throws IllegalArgumentException if {@code locs} is empty
 	 */
 	public static LocationList create(Location... locs) {
-		checkArgument(checkNotNull(locs).length > 0);
+		checkArgument(locs.length > 0);
 		return builder().add(locs).build();
 	}
 
 	/**
 	 * Create a new {@code LocationList} containing all {@code Location}s in
-	 * {@code locs}.
+	 * {@code locs}. This method avoids copying the supplied iterable if it is
+	 * safe to do so.
 	 * 
 	 * @param locs to populate list with
 	 * @throws IllegalArgumentException if {@code locs} is empty
 	 */
 	public static LocationList create(Iterable<Location> locs) {
-		checkArgument(checkNotNull(locs).iterator().hasNext());
+		checkArgument(locs.iterator().hasNext());
+		if (locs instanceof LocationList) {
+			return (LocationList) locs;
+		}
+		if (locs instanceof ImmutableList) {
+			return new RegularLocationList((ImmutableList<Location>) locs);
+		}
 		return builder().addAll(locs).build();
 	}
 
 	/**
-	 * Create a new {@code LocationList} by resampling the supplied list with
-	 * the desired maximum spacing. The actual spacing of the returned list will
-	 * likely differ, as spacing is adjusted down to maintain uniform divisions.
-	 * The original vertices are also not preserved such that some corners might
-	 * be adversely clipped if {@code spacing} is too large. Buyer beware.
-	 * 
-	 * <p>If a singleton list is supplied, it is immediately returned.
-	 * 
-	 * @param locs to resample
-	 * @param spacing resample interval
-	 * @return a new {@code LocationList}
-	 */
-	public static LocationList resample(LocationList locs, double spacing) {
-		if (checkNotNull(locs).size() == 1) return locs;
-		checkArgument(
-			Doubles.isFinite(spacing) && spacing > 0.0,
-			"Spacing must be positive, real number");
-		return resampled(locs, spacing);
-	}
-
-	/*
-	 * Actual spacing is computed using ceil() and is consistent current OpenSHA
-	 * practice when building gridded surfaces. This effectively sets the target
-	 * spacing as a maximum value. TODO Should consider using rint() which will
-	 * generally keep the actual spacing closer to the target spacing, albeit
-	 * sometimes larger.
-	 */
-	private static LocationList resampled(LocationList locs, double spacing) {
-		double length = locs.length();
-		spacing = length / Math.ceil(length / spacing);
-		LocationList.Builder builder = LocationList.builder();
-		Location start = locs.first();
-		builder.add(start);
-		double walker = spacing;
-		for (Location loc : Iterables.skip(locs, 1)) {
-			LocationVector v = LocationVector.create(start, loc);
-			double distance = Locations.horzDistanceFast(start, loc);
-			while (walker < distance) {
-				builder.add(Locations.location(start, v.azimuth(), walker));
-				walker += spacing;
-			}
-			start = loc;
-			walker -= distance;
-		}
-		if (walker < spacing / 2.0) builder.add(locs.last());
-		return builder.build();
-	}
-
-	/**
 	 * Create a new {@code LocationList} from the supplied {@code String}. This
-	 * method assumes that {@code s} is formatted in space-delimited xyz tuples,
-	 * each of which are comma-delimited with no spaces (e.g. KML style).
+	 * method assumes that {@code s} is formatted as one or more space-delimited
+	 * {@code [lat,lon,depth]} tuples (comma-delimited); see
+	 * {@link Location#fromString(String)}.
 	 * 
 	 * @param s {@code String} to read
 	 * @return a new {@code LocationList}
+	 * @see Location#fromString(String)
 	 */
 	public static LocationList fromString(String s) {
 		return create(Iterables.transform(
 			Parsing.split(checkNotNull(s), Delimiter.SPACE),
-			Location.fromStringFunction()));
+			Location.stringConverter().reverse()));
 	}
+
+	LocationList() {}
 
 	/**
 	 * Return the number of locations in this list.
@@ -147,11 +120,6 @@ public abstract class LocationList implements Iterable<Location> {
 	}
 
 	/**
-	 * Return a view of this list in reverse order.
-	 */
-	public abstract LocationList reverse();
-
-	/**
 	 * Lazily compute the horizontal length of this {@code LocationList} in km.
 	 * Method uses the {@link Locations#horzDistanceFast(Location, Location)}
 	 * algorithm and ignores depth variation between locations. That is, it
@@ -163,8 +131,8 @@ public abstract class LocationList implements Iterable<Location> {
 	 *         location
 	 */
 	public double length() {
-		if (size() == 1) return 0.0;
 		double sum = 0.0;
+		if (size() == 1) return sum;
 		Location prev = first();
 		for (Location loc : Iterables.skip(this, 1)) {
 			sum += Locations.horzDistanceFast(prev, loc);
@@ -184,14 +152,100 @@ public abstract class LocationList implements Iterable<Location> {
 		return depth / size();
 	}
 
-	@Override public String toString() {
+	@Override
+	public String toString() {
 		return NEWLINE + Joiner.on(NEWLINE).join(this) + NEWLINE;
 	}
 
-	/*
-	 * The default implementation that delegates to an ImmutableList.
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null) return false;
+		if (this == obj) return true;
+		if (!(obj instanceof LocationList)) return false;
+		LocationList other = (LocationList) obj;
+		if (this.size() != other.size()) return false;
+		return Iterators.elementsEqual(this.iterator(), other.iterator());
+	}
+
+	@Override
+	public int hashCode() {
+		return Lists.newArrayList(this).hashCode();
+	}
+
+	/**
+	 * Return a new {@code LocationList} created by resampling this list with
+	 * the desired maximum spacing. The actual spacing of the returned list will
+	 * likely differ, as spacing is adjusted down to maintain uniform divisions.
+	 * The original vertices are also not preserved such that some corners might
+	 * be adversely clipped if {@code spacing} is large. Buyer beware.
+	 * 
+	 * <p>For a singleton list, this method immediately returns this list.
+	 * 
+	 * @param spacing resample interval
 	 */
-	private static class RegularLocationList extends LocationList {
+	public LocationList resample(double spacing) {
+		if (size() == 1) {
+			return this;
+		}
+		checkArgument(
+			Doubles.isFinite(spacing) && spacing > 0.0,
+			"Spacing must be positive, real number");
+
+		/*
+		 * TODO Consider using rint() which will keep the actual spacing closer
+		 * to the target spacing, albeit sometimes larger.
+		 */
+
+		double length = this.length();
+		spacing = length / Math.ceil(length / spacing);
+		List<Location> resampled = Lists.newArrayList();
+		Location start = this.first();
+		resampled.add(start);
+		double walker = spacing;
+		for (Location loc : Iterables.skip(this, 1)) {
+			LocationVector v = LocationVector.create(start, loc);
+			double distance = Locations.horzDistanceFast(start, loc);
+			while (walker <= distance) {
+				resampled.add(Locations.location(start, v.azimuth(), walker));
+				walker += spacing;
+			}
+			start = loc;
+			walker -= distance;
+		}
+		// replace last point to be exact
+		resampled.set(resampled.size() - 1, this.last());
+		return LocationList.create(resampled);
+	}
+
+	/**
+	 * Return a new {@code LocationList} with {@code Location}s in reverse
+	 * order.
+	 */
+	public LocationList reverse() {
+		if (this instanceof RegularLocationList) {
+			return new RegularLocationList(((RegularLocationList) this).locs.reverse());
+		}
+		return create(ImmutableList.copyOf(this).reverse());
+	}
+
+	/**
+	 * Return a new {@code LocationList} with each {@code Location} translated
+	 * according to the supplied vector.
+	 * 
+	 * @param vector to translate list by
+	 */
+	public LocationList translate(final LocationVector vector) {
+		return builder().addAll(Iterables.transform(this, new Function<Location, Location>() {
+			@Override
+			public Location apply(Location loc) {
+				return Locations.location(loc, vector);
+			}
+		})).build();
+	}
+
+	/* The default implementation that delegates to an ImmutableList. */
+	@VisibleForTesting
+	static class RegularLocationList extends LocationList {
 
 		final ImmutableList<Location> locs;
 
@@ -199,33 +253,24 @@ public abstract class LocationList implements Iterable<Location> {
 			this.locs = locs;
 		}
 
-		@Override public int size() {
+		@Override
+		public int size() {
 			return locs.size();
 		}
 
-		@Override public Location get(int index) {
+		@Override
+		public Location get(int index) {
 			return locs.get(index);
 		}
 
-		@Override public Iterator<Location> iterator() {
+		@Override
+		public Iterator<Location> iterator() {
 			return locs.iterator();
-		}
-
-		@Override public LocationList reverse() {
-			return new RegularLocationList(locs.reverse());
-		}
-
-		@Override public int hashCode() {
-			return locs.hashCode();
-		}
-
-		@Override public boolean equals(Object obj) {
-			return locs.equals(obj);
 		}
 	}
 
 	/**
-	 * Return a new builder.
+	 * Return a new {@code LocationList} builder.
 	 */
 	public static Builder builder() {
 		return new Builder();
@@ -234,10 +279,14 @@ public abstract class LocationList implements Iterable<Location> {
 	/**
 	 * A reusable builder of {@code LocationList}s. Repeat calls to
 	 * {@code build()} will return multiple lists in series with each new list
-	 * containing all the {@code Location}s of the one before it.
+	 * containing all the {@code Location}s of the one before it. Builders do
+	 * not permit the addition of {@code null} elements.
+	 * 
+	 * <p>Use {@link LocationList#builder()} to create new builder instances.
 	 */
-	public static class Builder {
+	public static final class Builder {
 
+		@VisibleForTesting
 		ImmutableList.Builder<Location> builder;
 
 		private Builder() {
@@ -245,23 +294,23 @@ public abstract class LocationList implements Iterable<Location> {
 		}
 
 		/**
-		 * Adds a {@code Location} to the {@code LocationList}.
+		 * Add a {@code Location} to the {@code LocationList}.
 		 * 
 		 * @param loc to add
-		 * @return a reference to this {@code Builder}
+		 * @return this {@code Builder}
 		 */
 		public Builder add(Location loc) {
-			builder.add(checkNotNull(loc));
+			builder.add(loc);
 			return this;
 		}
 
 		/**
-		 * Adds a new {@code Location} specified by the supplied latitude and
+		 * Add a new {@code Location} specified by the supplied latitude and
 		 * longitude and a depth of 0 km to the {@code LocationList}.
 		 * 
 		 * @param lat latitude in decimal degrees
 		 * @param lon longitude in decimal degrees
-		 * @return a reference to this {@code Builder}
+		 * @return this {@code Builder}
 		 * @throws IllegalArgumentException if any values are out of range
 		 * @see GeoTools
 		 */
@@ -271,13 +320,13 @@ public abstract class LocationList implements Iterable<Location> {
 		}
 
 		/**
-		 * Adds a new {@code Location} specified by the supplied latitude,
+		 * Add a new {@code Location} specified by the supplied latitude,
 		 * longitude, and depth to the {@code LocationList}.
 		 * 
 		 * @param lat latitude in decimal degrees
 		 * @param lon longitude in decimal degrees
 		 * @param depth in km (positive down)
-		 * @return a reference to this {@code Builder}
+		 * @return this {@code Builder}
 		 * @throws IllegalArgumentException if any values are out of range
 		 * @see GeoTools
 		 */
@@ -287,11 +336,11 @@ public abstract class LocationList implements Iterable<Location> {
 		}
 
 		/**
-		 * Adds each {@code Location} in {@code locs} to the
+		 * Add each {@code Location} in {@code locs} to the
 		 * {@code LocationList}.
 		 * 
 		 * @param locs to add
-		 * @return a reference to this {@code Builder}
+		 * @return this {@code Builder}
 		 */
 		public Builder add(Location... locs) {
 			builder.add(locs);
@@ -299,11 +348,11 @@ public abstract class LocationList implements Iterable<Location> {
 		}
 
 		/**
-		 * Adds each {@code Location} in {@code locs} to the
+		 * Add each {@code Location} in {@code locs} to the
 		 * {@code LocationList}.
 		 * 
 		 * @param locs to add
-		 * @return a reference to this {@code Builder}
+		 * @return this {@code Builder}
 		 */
 		public Builder addAll(Iterable<Location> locs) {
 			builder.addAll(locs);
@@ -311,7 +360,7 @@ public abstract class LocationList implements Iterable<Location> {
 		}
 
 		/**
-		 * Returns a newly created {@code LocationList}.
+		 * Return a newly created {@code LocationList}.
 		 * 
 		 * @return a new ordered collection of {@code Location}s
 		 * @throws IllegalStateException if the list to be returned is empty
@@ -322,4 +371,5 @@ public abstract class LocationList implements Iterable<Location> {
 			return new RegularLocationList(locs);
 		}
 	}
+
 }

--- a/src/org/opensha2/geo/LocationVector.java
+++ b/src/org/opensha2/geo/LocationVector.java
@@ -90,8 +90,7 @@ public class LocationVector {
 	 * <p><b>NOTE</b>: create(p1, p2) is not equivalent to create
 	 * reverseOf(create(p2, p1)). Although the horizontal and vertical
 	 * components will likley be the same but the azimuths will potentially be
-
-	 * {@code p2}.
+	 * different.
 	 * 
 	 * @param v {@code LocationVector} to copy and flip
 	 * @return the flipped copy

--- a/src/org/opensha2/geo/Locations.java
+++ b/src/org/opensha2/geo/Locations.java
@@ -38,9 +38,6 @@ import com.google.common.base.Predicate;
  * href="http://www.movable-type.co.uk/scripts/latlong.html"
  * target="_blank">Moveable Type Scripts</a> for other implementations.</p>
  * 
- * <p>Unless explicitely stated, these methods do not perform any {@code null}
- * argument checking. TODO: should this be reconsidered</p>
- * 
  * @author Peter Powers
  * @see Location
  */

--- a/src/org/opensha2/geo/Locations.java
+++ b/src/org/opensha2/geo/Locations.java
@@ -45,6 +45,13 @@ import com.google.common.base.Predicate;
  * @see Location
  */
 public final class Locations {
+	
+	/*
+	 * TODO It's good to have these algorithms all in one file. However,
+	 * it might be noice to add methods such as translate(vector) or
+	 * distanceTo(loc) to Location, which would allow more elegant method
+	 * chaining.
+	 */
 
 	/*
 	 * Developer Notes: All experimental, exploratory and test methods were

--- a/src/org/opensha2/geo/Locations.java
+++ b/src/org/opensha2/geo/Locations.java
@@ -1,26 +1,34 @@
 package org.opensha2.geo;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.math.DoubleMath.fuzzyEquals;
 import static java.lang.Math.PI;
 import static java.lang.Math.abs;
-import static java.lang.Math.atan2;
 import static java.lang.Math.acos;
 import static java.lang.Math.asin;
+import static java.lang.Math.atan2;
 import static java.lang.Math.cos;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.sin;
 import static java.lang.Math.sqrt;
-import static com.google.common.math.DoubleMath.fuzzyEquals;
-import static org.opensha2.geo.Direction.NORTH;
-import static org.opensha2.geo.Direction.WEST;
-import static org.opensha2.geo.GeoTools.*;
+import static org.opensha2.geo.GeoTools.EARTH_RADIUS_MEAN;
+import static org.opensha2.geo.GeoTools.MAX_LAT;
+import static org.opensha2.geo.GeoTools.MAX_LON;
+import static org.opensha2.geo.GeoTools.MIN_LAT;
+import static org.opensha2.geo.GeoTools.MIN_LON;
+import static org.opensha2.geo.GeoTools.TO_DEG;
+import static org.opensha2.geo.GeoTools.TO_RAD;
+import static org.opensha2.geo.GeoTools.TWOPI;
+import static org.opensha2.geo.GeoTools.degreesLatPerKm;
+import static org.opensha2.geo.GeoTools.degreesLonPerKm;
 
 import java.awt.geom.Line2D;
+import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
 import java.util.Collection;
 
 import com.google.common.base.Predicate;
-import com.google.common.math.DoubleMath;
 
 /**
  * Static utility methods to operate on geographic {@code Location} data.
@@ -685,6 +693,91 @@ public final class Locations {
 		lonRad /= size;
 		depth /= size;
 		return Location.create(latRad * TO_DEG, lonRad * TO_DEG, depth);
+	}
+
+	/**
+	 * Return a closed, straight-line {@link Path2D} representation of the
+	 * supplied list, ignoring depth.
+	 */
+	public static Path2D toPath(LocationList locs) {
+		Path2D path = new Path2D.Double(Path2D.WIND_EVEN_ODD, locs.size());
+		boolean starting = true;
+		for (Location loc : locs) {
+			double lat = loc.lat();
+			double lon = loc.lon();
+			// if just starting, then moveTo
+			if (starting) {
+				path.moveTo(lon, lat);
+				starting = false;
+				continue;
+			}
+			path.lineTo(lon, lat);
+		}
+		path.closePath();
+		return path;
+	}
+
+	/**
+	 * Compute the horizontal distance (in km) from a {@code Location} to the
+	 * closest point in a {@code LocationList}. This method uses
+	 * {@link #horzDistanceFast(Location, Location)} to compute the distance.
+	 * 
+	 * @param loc {@code Location} of interest
+	 * @param locs {@code LocationList} to compute distance to
+	 * @see #horzDistanceFast(Location, Location)
+	 */
+	public static double minDistanceToLocations(Location loc, LocationList locs) {
+		double min = Double.MAX_VALUE;
+		double dist = 0;
+		for (Location p : locs) {
+			dist = Locations.horzDistanceFast(loc, p);
+			if (dist < min) min = dist;
+		}
+		return min;
+	}
+
+	/**
+	 * Compute the shortest horizontal distance (in km) from a {@code Location}
+	 * to the line defined by connecting the points in a {@code LocationList}.
+	 * This method uses
+	 * {@link Locations#distanceToSegmentFast(Location, Location, Location)} and
+	 * is inappropriate for for use at large separations (e.g. >200 km).
+	 * 
+	 * @param loc {@code Location} of interest
+	 * @param locs {@code LocationList} to compute distance to
+	 * @see #distanceToSegmentFast(Location, Location, Location)
+	 */
+	public static double minDistanceToLine(Location loc, LocationList locs) {
+		if (locs.size() == 1) return horzDistanceFast(loc, locs.get(0));
+		double min = Double.MAX_VALUE;
+		for (int i = 0; i < locs.size() - 1; i++) {
+			min = Math.min(min, distanceToSegmentFast(locs.get(i), locs.get(i + 1), loc));
+		}
+		return min;
+	}
+
+	/**
+	 * Compute the segment index that is closest to a {@code Location}. There
+	 * are {@code locs.size() - 1} segment indices. The indices of the segment
+	 * endpoints in the original location list are {@code [n, n+1]}.
+	 * 
+	 * @param loc {@code Location} of interest
+	 * @param locs {@code LocationList} for which to compute the closest segment
+	 *        index
+	 * @throws IllegalArgumentException if {@code locs.size() < 2}
+	 */
+	public static int minDistanceIndex(Location loc, LocationList locs) {
+		checkArgument(locs.size() > 1);
+		double min = Double.MAX_VALUE;
+		int minIndex = -1;
+		for (int i = 0; i < locs.size() - 1; i++) {
+			double dist = distanceToSegmentFast(locs.get(i), locs.get(i + 1), loc);
+			if (dist < min) {
+				min = dist;
+				minIndex = i;
+			}
+		}
+		return minIndex;
 	}
 
 	/**

--- a/src/org/opensha2/geo/Region.java
+++ b/src/org/opensha2/geo/Region.java
@@ -345,7 +345,7 @@ public class Region implements Named {
 	public double distanceToLocation(Location loc) {
 		checkNotNull(loc, "Supplied location is null");
 		if (contains(loc)) return 0;
-		double min = border.minDistToLine(loc);
+		double min = Locations.minDistanceToLine(loc, border);
 		// check the segment defined by the last and first points
 		// take abs because value may be negative; i.e. value to left of line
 		double temp = Math.abs(Locations.distanceToSegmentFast(border.get(border.size() - 1),
@@ -424,7 +424,8 @@ public class Region implements Named {
 		// first remove last point in list if it is the same as
 		// the first point
 		if (border.get(border.size() - 1).equals(border.get(0))) {
-			border.locs.remove(border.size() - 1);
+			border = LocationList.create(Iterables.limit(border, border.size() - 1));
+//			border.locs.remove(border.size() - 1); TODO test/clean locList refactor
 		}
 
 		if (type.equals(GREAT_CIRCLE)) {
@@ -533,7 +534,7 @@ public class Region implements Named {
 	 * throw exceptions if the generated Area is empty or not singular
 	 */
 	private static Area areaFromBorder(LocationList border) {
-		Area area = new Area(border.toPath());
+		Area area = new Area(Locations.toPath(border));
 		// final checks on area generated, this is redundant for some
 		// constructors that perform other checks on inputs
 		checkArgument(!area.isEmpty(), "Internally computed Area is empty");

--- a/src/org/opensha2/geo/RegionUtils.java
+++ b/src/org/opensha2/geo/RegionUtils.java
@@ -459,7 +459,7 @@ public class RegionUtils {
 			Location.create(nodeLat - halfH, nodeLon + halfW), // bot right
 			Location.create(nodeLat - halfH, nodeLon - halfW), // bot left
 			Location.create(nodeLat + halfH, nodeLon - halfW)); // top left
-		return new Area(locs.toPath());
+		return new Area(Locations.toPath(locs));
 	}
 
 

--- a/src/org/opensha2/geo/package-info.java
+++ b/src/org/opensha2/geo/package-info.java
@@ -1,7 +1,19 @@
 /**
  * Classes and utilities for working with geographic data.
  * 
- * <p>All utility methods in this package assume that depths are positive-down,
- * consistent with seismological convention.
+ * <p>All objects and methods in this package assume that depths are
+ * positive-down, consistent with seismological convention.
+ * 
+ * <p>Note that while the objects and methods of this package produce reliable
+ * results for most regions of the globe, situations may arise in which users
+ * encounter unexpected behaviour and results. For instance, the 'fast'
+ * algorithms in {@link org.opensha2.geo.Locations} (e.g.
+ * {@link org.opensha2.geo.Locations#horzDistanceFast(Location, Location)}) will
+ * not produce accurate results when used in close proximity to the poles or
+ * when locations span the antimeridian (the -180° +180° transition). In such
+ * cases, users should consider substituting slower, but more accurate
+ * algorithms. In the latter case, one could alternatively opt to use locations
+ * referenced to 0° to 360° instead. Exceptional behavior is well documented in
+ * the {@link org.opensha2.geo.Locations} class.
  */
 package org.opensha2.geo;

--- a/src/org/opensha2/geo/package-info.java
+++ b/src/org/opensha2/geo/package-info.java
@@ -1,4 +1,7 @@
 /**
  * Classes and utilities for working with geographic data.
+ * 
+ * <p>All utility methods in this package assume that depths are positive-down,
+ * consistent with seismological convention.
  */
 package org.opensha2.geo;

--- a/test/org/opensha2/eq/fault/surface/DefaultGriddedSurfaceTest.java
+++ b/test/org/opensha2/eq/fault/surface/DefaultGriddedSurfaceTest.java
@@ -1,0 +1,42 @@
+package org.opensha2.eq.fault.surface;
+
+import static org.junit.Assert.*;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensha2.geo.Location;
+import org.opensha2.geo.LocationList;
+
+@SuppressWarnings("javadoc")
+public class DefaultGriddedSurfaceTest {
+
+
+	@Test public final void testBuilder() {
+		
+		DefaultGriddedSurface surface = createBasic();
+		
+		assertEquals(surface.dipSpacing, 1.0, 0.0);
+		assertEquals(surface.strikeSpacing, 0.9884, 0.000001);
+		
+		assertEquals(surface.numRows, 16);
+		assertEquals(surface.numCols, 46);
+		
+	}
+	
+	private static DefaultGriddedSurface createBasic() {
+		
+		LocationList trace = LocationList.create(
+			Location.create(34.0, -118.0),
+			Location.create(34.4, -118.0));
+
+		DefaultGriddedSurface surface = DefaultGriddedSurface.builder()
+				.trace(trace)
+				.depth(0.0)
+				.dip(90.0)
+				.width(15.0)
+				.build();
+
+		return surface;
+	}
+
+}

--- a/test/org/opensha2/eq/fault/surface/DefaultGriddedSurfaceTest.java
+++ b/test/org/opensha2/eq/fault/surface/DefaultGriddedSurfaceTest.java
@@ -2,7 +2,6 @@ package org.opensha2.eq.fault.surface;
 
 import static org.junit.Assert.*;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opensha2.geo.Location;
 import org.opensha2.geo.LocationList;

--- a/test/org/opensha2/eq/fault/surface/RuptureFloatingTest.java
+++ b/test/org/opensha2/eq/fault/surface/RuptureFloatingTest.java
@@ -1,0 +1,54 @@
+package org.opensha2.eq.fault.surface;
+
+import static org.junit.Assert.*;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensha2.geo.Location;
+import org.opensha2.geo.LocationList;
+
+public class RuptureFloatingTest {
+
+	@BeforeClass public static void setUpBeforeClass() throws Exception {}
+
+//	@Test public final void testCreateFloatingRuptures() {
+//		fail("Not yet implemented"); // TODO
+//	}
+//
+	@Test public final void testOff() {
+		
+		LocationList trace = LocationList.create(
+			Location.create(34.0, -118.0),
+			Location.create(34.4, -118.0));
+				
+		DefaultGriddedSurface surface = DefaultGriddedSurface.builder()
+				.trace(trace)
+				.dip(90)
+				.width(15.0)
+				.build();
+		
+		fail("Not yet implemented"); // TODO
+	}
+	
+	
+	public static void main(String[] args) {
+
+		LocationList trace = LocationList.create(
+			Location.create(34.0, -118.0),
+			Location.create(34.4, -118.0));
+
+		DefaultGriddedSurface surface = DefaultGriddedSurface.builder()
+				.trace(trace)
+				.depth(0.0)
+				.dip(90.0)
+				.width(15.0)
+				.build();
+		
+		System.out.println(surface);
+		System.out.println(surface.dipSpacing);
+		System.out.println(surface.strikeSpacing);
+		System.out.println(surface.numRows);
+		System.out.println(surface.numCols);
+
+	}
+}

--- a/test/org/opensha2/geo/LocationListTest.java
+++ b/test/org/opensha2/geo/LocationListTest.java
@@ -1,0 +1,366 @@
+package org.opensha2.geo;
+
+import static org.junit.Assert.*;
+import static org.opensha2.util.TextUtils.NEWLINE;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensha2.eq.fault.surface.DefaultGriddedSurface;
+import org.opensha2.geo.LocationList.RegularLocationList;
+import org.opensha2.util.TextUtils;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+@SuppressWarnings("javadoc")
+public class LocationListTest {
+
+	private static LocationList locs1, locs2;
+	private static Location p1, p2, p3, p4, p5, p6, p7;
+	private static Location pp1, pp2;
+
+	private static Location g00, g01, g02, g03, g10, g11, g12, g13;
+	private static LocationGrid grid;
+
+	@BeforeClass
+	public static void setUp() {
+		p1 = Location.create(-5, 0);
+		p2 = Location.create(-3, -2);
+		p3 = Location.create(-2, -2);
+		p4 = Location.create(0, 0);
+		p5 = Location.create(2, 2);
+		p6 = Location.create(3, 2);
+		p7 = Location.create(5, 0);
+
+		pp1 = Location.create(0, 0);
+		pp2 = Location.create(1, 1);
+
+		locs1 = LocationList.create(p1, p2, p3, p4, p5, p6, p7);
+		locs2 = LocationList.create(p1, p3, p2, p4, p6, p5, p7);
+
+		g00 = Location.create(0, 0);
+		g01 = Location.create(1, 0);
+		g02 = Location.create(2, 0);
+		g03 = Location.create(3, 0);
+		g10 = Location.create(0, 1);
+		g11 = Location.create(1, 1);
+		g12 = Location.create(2, 1);
+		g13 = Location.create(3, 1);
+		grid = LocationGrid.builder(2, 4)
+			.fillRow(0, LocationList.builder().add(g00, g01, g02, g03).build())
+			.fillRow(1, LocationList.builder().add(g10, g11, g12, g13).build())
+			.build();
+	}
+
+	/* Factory */
+
+	@Test
+	public final void create() {
+		LocationList locs = LocationList.create(p1, p2, p3, p4, p5, p6, p7);
+		assertEquals(locs, locs1);
+		List<Location> il = ImmutableList.of(p1, p2, p3, p4, p5, p6, p7);
+		locs = LocationList.create(il);
+		assertEquals(locs, locs1);
+		assertSame(il, ((RegularLocationList) locs).locs);
+		locs = LocationList.create(locs1);
+		assertSame(locs, locs1);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public final void create_NPE1() {
+		Location[] locs = null;
+		LocationList.create(locs);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public final void create_IAE1() {
+		Location[] locs = new Location[] {};
+		LocationList.create(locs);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public final void create_NPE2() {
+		List<Location> locs = null;
+		LocationList.create(locs);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public final void create_IAE2() {
+		List<Location> locs = ImmutableList.of();
+		LocationList.create(locs);
+	}
+
+	@Test
+	public final void resample() {
+		LocationList locs = LocationList.create(pp1, pp2);
+		LocationList resampled = locs.resample(12);
+		assertEquals(resampled.size(), 15);
+		assertSame(resampled.first(), pp1);
+		assertSame(resampled.last(), pp2);
+		Location mid = resampled.get(7);
+		assertEquals(mid.lon(), 0.49996509384838933, 0.0);
+		assertEquals(mid.lat(), 0.5000222122727477, 0.0);
+
+		// singleton
+		locs = LocationList.create(pp1);
+		resampled = locs.resample(1.0);
+		assertSame(locs, resampled);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public final void resample_IAE1() {
+		LocationList locs = LocationList.create(pp1, pp2);
+		locs.resample(Double.POSITIVE_INFINITY);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public final void resample_IAE2() {
+		LocationList locs = LocationList.create(pp1, pp2);
+		locs.resample(-1.0);
+	}
+
+	public static void main(String[] args) {
+//		Location pp1 = Location.create(0, 0);
+//		Location pp2 = Location.create(1, 1);
+//
+//		LocationList ll1 = null;
+//		LocationList ll2 = LocationList.create(pp1, pp2);
+//
+//		assertEquals(ll1, ll2);
+		//
+		// LocationList locs = LocationList.create(pp1, pp2);
+		// LocationVector v = LocationVector.create(135 * GeoTools.TO_RAD, 5.0,
+		// 5.0);
+		// LocationList translated = locs.translate(v);
+		// System.out.println(translated);
+		//
+		// System.out.println("---");
+		// System.out.println(translated.get(0).lat());
+		// System.out.println(translated.get(0).lon());
+		// System.out.println(translated.get(0).depth());
+		// System.out.println("---");
+		// System.out.println(translated.get(1).lat());
+		// System.out.println(translated.get(1).lon());
+		// System.out.println(translated.get(1).depth());
+		// System.out.println("---");
+
+		// LocationList locs = LocationList.create(pp1, pp2);
+		// LocationList resampled = locs.resample(12);
+		// System.out.println(resampled);
+
+		// List<Location> pp1 = ImmutableList.of(p1, p2, p3);
+		// Iterable<Location> pp2 = LocationList.create(p1, p2, p3);
+		// Iterable<Location> pp3 = LocationList.create(p1, p2, p3);
+		// System.out.println(pp3.equals(pp2));
+
+		// String locStr = new StringBuilder(NEWLINE)
+		// .append("0.00000,0.00000,0.00000").append(NEWLINE)
+		// .append("1.00000,1.00000,0.00000").append(NEWLINE)
+		// .toString();
+		// LocationList locs = LocationList.create(pp1, pp2);
+		//
+		// System.out.println("----");
+		// System.out.println(locStr);
+		// System.out.println("----");
+		// System.out.println(locs);
+		// System.out.println("----");
+		
+		List<Integer> pp1 = Lists.newArrayList(2,4,7,31);
+		List<Integer> pp2 = ImmutableList.of(2,4,7,31);
+		System.out.println(pp1.hashCode());
+		System.out.println(pp2.hashCode());
+		
+	}
+
+	@Test
+	public final void reverse() {
+
+		// this tests the default RegularLocationList
+		LocationList reversed = locs1.reverse();
+		assertSame(locs1.get(0), reversed.get(6));
+		assertSame(locs1.get(1), reversed.get(5));
+		assertSame(locs1.get(2), reversed.get(4));
+		assertSame(locs1.get(4), reversed.get(2));
+		assertSame(locs1.get(5), reversed.get(1));
+		assertSame(locs1.get(6), reversed.get(0));
+
+		// use LocationGrid to test fall through to
+		// other LocList implementations
+		LocationList reversedRow = grid.row(1).reverse();
+		assertSame(g10, reversedRow.get(3));
+		assertSame(g11, reversedRow.get(2));
+		assertSame(g12, reversedRow.get(1));
+		assertSame(g13, reversedRow.get(0));
+	}
+
+	@Test
+	public final void translate() {
+		LocationList locs = LocationList.create(pp1, pp2);
+		LocationVector v = LocationVector.create(135 * GeoTools.TO_RAD, 5.0, 5.0);
+		LocationList transLoc = locs.translate(v);
+		Location pp1trans = Location.create(-0.03179578273558637, 0.031795787631496104, 5.0);
+		Location pp2trans = Location.create(0.9682040632704144, 1.031800322985746, 5.0);
+		assertEquals(pp1trans, transLoc.get(0));
+		assertEquals(pp2trans, transLoc.get(1));
+	}
+
+	@Test
+	public final void fromString() {
+		String locStr = "-117.0,34.0,0.1 -117.0,34.1,0.2 -117.1,34.0,0.3";
+		LocationList locsFromString = LocationList.fromString(locStr);
+		LocationList locsActual = LocationList.create(
+			Location.create(34.0, -117.0, 0.1),
+			Location.create(34.1, -117.0, 0.2),
+			Location.create(34.0, -117.1, 0.3));
+		assertEquals(locsFromString, locsActual);
+	}
+
+	/* Object */
+
+	@Test
+	public final void hashCodeTest() {
+		// copy create should return the same list
+		LocationList copy = LocationList.create(locs1);
+		assertEquals(copy.hashCode(), locs1.hashCode());
+		// using builder should copy locations
+		copy = LocationList.builder().addAll(locs1).build();
+		assertEquals(copy.hashCode(), locs1.hashCode());
+		assertNotEquals(locs1.hashCode(), locs2.hashCode());
+		// because hash code is based on backing list
+		// implementation, check that too
+		List<Location> locs = ImmutableList.copyOf(locs1);
+		assertEquals(locs.hashCode(), locs1.hashCode());
+	}
+
+	@Test
+	public final void equalsTest() {
+		LocationList equal = null;
+		assertNotEquals(locs1, equal);
+		assertEquals(locs1, locs1);
+		assertNotEquals(locs1, "test");
+		equal = LocationList.create(p1, p2, p3, p4, p5, p6, p7);
+		assertEquals(locs1, equal);
+		assertNotEquals(locs1, locs2);
+		
+		// size check
+		equal = LocationList.create(p1, p2, p3, p4, p5);
+		assertNotEquals(locs1, equal);
+	}
+
+	@Test
+	public final void toStringTest() {
+		String locStr = new StringBuilder(NEWLINE)
+			.append("0.00000,0.00000,0.00000").append(NEWLINE)
+			.append("1.00000,1.00000,0.00000").append(NEWLINE)
+			.toString();
+		LocationList locs = LocationList.create(pp1, pp2);
+		assertEquals(locStr, locs.toString());
+	}
+
+	/* Methods */
+
+	@Test
+	public final void size() {
+		assertEquals(locs1.get(0), locs1.first());
+	}
+
+	@Test
+	public final void get() {
+		assertSame(locs1.get(0), p1);
+		assertSame(locs1.get(2), p3);
+		assertSame(locs1.get(4), p5);
+		assertSame(locs1.get(6), p7);
+	}
+
+	@Test
+	public final void first() {
+		assertSame(locs1.get(0), locs1.first());
+	}
+
+	@Test
+	public final void last() {
+		assertSame(locs1.get(locs1.size() - 1), locs1.last());
+	}
+
+	@Test
+	public final void length() {
+		assertEquals(1479.6049574653778, locs1.length(), 0.0);
+		assertEquals(157.25055720494782, LocationList.create(pp1, pp2).length(), 0.0);
+		assertEquals(0.0, LocationList.create(p1).length(), 0.0);
+	}
+
+	@Test
+	public final void depth() {
+		LocationList locs = LocationList.create(
+			Location.create(0, 0, 0),
+			Location.create(1, 1, 0),
+			Location.create(2, 2, 1));
+		assertEquals(0.3333333333333333, locs.depth(), 0.0);
+	}
+
+	/* Builder */
+
+	@Test
+	public final void builder() {
+		LocationList.Builder b = LocationList.builder();
+		assertNotNull(b.builder);
+		assertThat(b.builder, CoreMatchers.instanceOf(ImmutableList.Builder.class));
+
+		LocationList locs = b.add(p1).build();
+		assertEquals(1, locs.size());
+		assertSame(locs.get(0), p1);
+
+		double lat = 34.001;
+		double lon = -117.044;
+		locs = b.add(lat, lon).build();
+		assertEquals(2, locs.size());
+		assertEquals(locs.get(1), Location.create(lat, lon));
+
+		double depth = 3.2;
+		locs = b.add(lat, lon, depth).build();
+		assertEquals(3, locs.size());
+		assertEquals(locs.get(2), Location.create(lat, lon, depth));
+
+		locs = b.add(p1, p2, p3).build();
+		assertEquals(6, locs.size());
+		assertSame(locs.get(5), p3);
+
+		List<Location> locList = Lists.newArrayList(p4, p5, p6);
+		locs = b.addAll(locList).build();
+		assertEquals(9, locs.size());
+		assertSame(locs.get(8), p6);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public final void builderAdd_NPE1() {
+		Location loc = null;
+		LocationList.builder().add(loc);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public final void builderAdd_NPE2() {
+		Location loc = null;
+		LocationList.builder().add(Location.create(0, 0), loc);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public final void builderAdd_NPE3() {
+		List<Location> locs = Lists.newArrayList(
+			Location.create(0, 0), null);
+		LocationList.builder().addAll(locs);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public final void builderBuild_ISE() {
+		LocationList.builder().build();
+	}
+
+}

--- a/test/org/opensha2/geo/LocationTest.java
+++ b/test/org/opensha2/geo/LocationTest.java
@@ -1,0 +1,138 @@
+package org.opensha2.geo;
+
+import static org.junit.Assert.*;
+import static org.opensha2.geo.GeoTools.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+@SuppressWarnings("javadoc")
+public class LocationTest {
+
+	private static final double V = 10.0;
+	Location location;
+
+	@Before public void setUp() throws Exception {
+		location = Location.create(V, V, V);
+	}
+
+	@Test public final void create() {
+		Location loc = Location.create(V, V, V);
+		assertEquals(loc.lat(), V, 0);
+		assertEquals(loc.lon(), V, 0);
+		assertEquals(loc.depth(), V, 0);
+
+		loc = Location.create(V, V);
+		assertEquals(loc.depth(), 0, 0);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public final void createIAE1() {
+		Location.create(MAX_LAT + 0.1, 0);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public final void createIAE2() {
+		Location.create(MIN_LAT - 0.1, 0);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public final void createIAE3() {
+		Location.create(0, MAX_LON + 0.1);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public final void createIAE4() {
+		Location.create(0, MIN_LON - 0.1);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public final void createIAE5() {
+		Location.create(0, 0, MAX_DEPTH + 0.1);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public final void createIAE6() {
+		Location.create(0, 0, MIN_DEPTH - 0.1);
+	}
+	
+	@Test public final void fromString() {
+		String s = "10.0,10.0,10.0";
+		assertEquals(Location.fromString(s), location);
+	}
+
+	@Test public final void depth() {
+		assertEquals(location.depth(), 10, 0);
+	}
+
+	@Test public final void lat() {
+		assertEquals(location.lat(), 10, 0);
+	}
+
+	@Test public final void lon() {
+		assertEquals(location.lon(), 10, 0);
+	}
+
+	@Test public final void latRad() {
+		assertEquals(location.latRad(), V * TO_RAD, 0);
+	}
+
+	@Test public final void lonRad() {
+		assertEquals(location.lonRad(), V * TO_RAD, 0);
+	}
+
+	@Test public final void toStringTest() {
+		Location loc = Location.create(20, 30, 10);
+		String s = String.format("%.5f,%.5f,%.5f", loc.lon(), loc.lat(), loc.depth());
+		assertEquals(loc.toString(), s);
+	}
+
+	@Test public final void equalsTest() {
+		// same object
+		assertEquals(location, location);
+		// different object type
+		assertFalse(location.equals("test"));
+		// same values
+		Location loc = Location.create(V, V, V);
+		assertEquals(location, loc);
+		// different values
+		loc = Location.create(V + 0.1, V, V);
+		assertNotEquals(location, loc);
+		loc = Location.create(V, V + 0.1, V);
+		assertNotEquals(location, loc);
+		loc = Location.create(V, V, V + 0.1);
+		assertNotEquals(location, loc);
+	}
+
+	@Test public final void hashCodeTest() {
+		Location other = Location.create(V, V, V);
+		assertEquals(location.hashCode(), other.hashCode());
+		Location locA = Location.create(45, 90, 25);
+		Location locB = Location.create(90, 45, 25);
+		assertNotEquals(locA.hashCode(), locB.hashCode());
+	}
+
+	@Test public final void compareToTest() {
+		Location l0 = Location.create(20, -30);
+		Location l1 = Location.create(20, -50);
+		Location l2 = Location.create(-10, 10);
+		Location l3 = Location.create(-10, 30);
+		Location l4 = Location.create(-10, 30);
+		Location l5 = Location.create(40, 10);
+		List<Location> locList = Lists.newArrayList(l0, l1, l2, l3, l4, l5);
+		Collections.sort(locList);
+		assertTrue(locList.get(0) == l2);
+		assertTrue(locList.get(1) == l3);
+		assertTrue(locList.get(2) == l4);
+		assertTrue(locList.get(3) == l1);
+		assertTrue(locList.get(4) == l0);
+		assertTrue(locList.get(5) == l5);
+	}
+
+}

--- a/test/org/opensha2/geo/LocationTest.java
+++ b/test/org/opensha2/geo/LocationTest.java
@@ -1,12 +1,20 @@
 package org.opensha2.geo;
 
-import static org.junit.Assert.*;
-import static org.opensha2.geo.GeoTools.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.opensha2.geo.GeoTools.MAX_DEPTH;
+import static org.opensha2.geo.GeoTools.MAX_LAT;
+import static org.opensha2.geo.GeoTools.MAX_LON;
+import static org.opensha2.geo.GeoTools.MIN_DEPTH;
+import static org.opensha2.geo.GeoTools.MIN_LAT;
+import static org.opensha2.geo.GeoTools.MIN_LON;
+import static org.opensha2.geo.GeoTools.TO_RAD;
 
 import java.util.Collections;
 import java.util.List;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -18,11 +26,13 @@ public class LocationTest {
 	private static final double V = 10.0;
 	Location location;
 
-	@Before public void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		location = Location.create(V, V, V);
 	}
 
-	@Test public final void create() {
+	@Test
+	public final void create() {
 		Location loc = Location.create(V, V, V);
 		assertEquals(loc.lat(), V, 0);
 		assertEquals(loc.lon(), V, 0);
@@ -32,72 +42,88 @@ public class LocationTest {
 		assertEquals(loc.depth(), 0, 0);
 	}
 
-	@Test(expected = IllegalArgumentException.class)public final void createIAE1() {
+	@Test(expected = IllegalArgumentException.class)
+	public final void create_IAE1() {
 		Location.create(MAX_LAT + 0.1, 0);
 	}
 
-	@Test(expected = IllegalArgumentException.class) public final void createIAE2() {
+	@Test(expected = IllegalArgumentException.class)
+	public final void create_IAE2() {
 		Location.create(MIN_LAT - 0.1, 0);
 	}
 
-	@Test(expected = IllegalArgumentException.class) public final void createIAE3() {
+	@Test(expected = IllegalArgumentException.class)
+	public final void create_IAE3() {
 		Location.create(0, MAX_LON + 0.1);
 	}
 
-	@Test(expected = IllegalArgumentException.class) public final void createIAE4() {
+	@Test(expected = IllegalArgumentException.class)
+	public final void create_IAE4() {
 		Location.create(0, MIN_LON - 0.1);
 	}
 
-	@Test(expected = IllegalArgumentException.class) public final void createIAE5() {
+	@Test(expected = IllegalArgumentException.class)
+	public final void create_IAE5() {
 		Location.create(0, 0, MAX_DEPTH + 0.1);
 	}
 
-	@Test(expected = IllegalArgumentException.class) public final void createIAE6() {
+	@Test(expected = IllegalArgumentException.class)
+	public final void create_IAE6() {
 		Location.create(0, 0, MIN_DEPTH - 0.1);
 	}
 
-	@Test public final void fromString() {
+	@Test
+	public final void fromString() {
 		String s = "10.0,10.0,10.0";
 		assertEquals(Location.fromString(s), location);
 	}
 
-	@Test(expected = NumberFormatException.class) public final void fromStringNFE() {
+	@Test(expected = NumberFormatException.class)
+	public final void fromString_NFE() {
 		String s = "10.0,x,10.0";
 		Location.fromString(s);
 	}
 
-	@Test(expected = IndexOutOfBoundsException.class) public final void fromStringIOOBE() {
+	@Test(expected = IndexOutOfBoundsException.class)
+	public final void fromString_IOOBE() {
 		String s = "10.0,10.0";
 		Location.fromString(s);
 	}
 
-	@Test public final void depth() {
+	@Test
+	public final void depth() {
 		assertEquals(location.depth(), 10, 0);
 	}
 
-	@Test public final void lat() {
+	@Test
+	public final void lat() {
 		assertEquals(location.lat(), 10, 0);
 	}
 
-	@Test public final void lon() {
+	@Test
+	public final void lon() {
 		assertEquals(location.lon(), 10, 0);
 	}
 
-	@Test public final void latRad() {
+	@Test
+	public final void latRad() {
 		assertEquals(location.latRad(), V * TO_RAD, 0);
 	}
 
-	@Test public final void lonRad() {
+	@Test
+	public final void lonRad() {
 		assertEquals(location.lonRad(), V * TO_RAD, 0);
 	}
 
-	@Test public final void toStringTest() {
+	@Test
+	public final void toStringTest() {
 		Location loc = Location.create(20, 30, 10);
 		String s = String.format("%.5f,%.5f,%.5f", loc.lon(), loc.lat(), loc.depth());
 		assertEquals(loc.toString(), s);
 	}
 
-	@Test public final void equalsTest() {
+	@Test
+	public final void equalsTest() {
 		// same object
 		assertEquals(location, location);
 		// different object type
@@ -114,7 +140,8 @@ public class LocationTest {
 		assertNotEquals(location, loc);
 	}
 
-	@Test public final void hashCodeTest() {
+	@Test
+	public final void hashCodeTest() {
 		Location other = Location.create(V, V, V);
 		assertEquals(location.hashCode(), other.hashCode());
 		Location locA = Location.create(45, 90, 25);
@@ -122,7 +149,8 @@ public class LocationTest {
 		assertNotEquals(locA.hashCode(), locB.hashCode());
 	}
 
-	@Test public final void compareToTest() {
+	@Test
+	public final void compareToTest() {
 		Location l0 = Location.create(20, -30);
 		Location l1 = Location.create(20, -50);
 		Location l2 = Location.create(-10, 10);

--- a/test/org/opensha2/geo/LocationTest.java
+++ b/test/org/opensha2/geo/LocationTest.java
@@ -167,8 +167,4 @@ public class LocationTest {
 		assertTrue(locList.get(5) == l5);
 	}
 
-	public static void main(String[] args) {
-		Location loc = Location.fromString("10, 20, 30, 40");
-	}
-
 }

--- a/test/org/opensha2/geo/LocationTest.java
+++ b/test/org/opensha2/geo/LocationTest.java
@@ -31,40 +31,44 @@ public class LocationTest {
 		loc = Location.create(V, V);
 		assertEquals(loc.depth(), 0, 0);
 	}
-	
-	@Test(expected=IllegalArgumentException.class)
-	public final void createIAE1() {
+
+	@Test(expected = IllegalArgumentException.class)public final void createIAE1() {
 		Location.create(MAX_LAT + 0.1, 0);
 	}
 
-	@Test(expected=IllegalArgumentException.class)
-	public final void createIAE2() {
+	@Test(expected = IllegalArgumentException.class) public final void createIAE2() {
 		Location.create(MIN_LAT - 0.1, 0);
 	}
-	
-	@Test(expected=IllegalArgumentException.class)
-	public final void createIAE3() {
+
+	@Test(expected = IllegalArgumentException.class) public final void createIAE3() {
 		Location.create(0, MAX_LON + 0.1);
 	}
-	
-	@Test(expected=IllegalArgumentException.class)
-	public final void createIAE4() {
+
+	@Test(expected = IllegalArgumentException.class) public final void createIAE4() {
 		Location.create(0, MIN_LON - 0.1);
 	}
 
-	@Test(expected=IllegalArgumentException.class)
-	public final void createIAE5() {
+	@Test(expected = IllegalArgumentException.class) public final void createIAE5() {
 		Location.create(0, 0, MAX_DEPTH + 0.1);
 	}
-	
-	@Test(expected=IllegalArgumentException.class)
-	public final void createIAE6() {
+
+	@Test(expected = IllegalArgumentException.class) public final void createIAE6() {
 		Location.create(0, 0, MIN_DEPTH - 0.1);
 	}
-	
+
 	@Test public final void fromString() {
 		String s = "10.0,10.0,10.0";
 		assertEquals(Location.fromString(s), location);
+	}
+
+	@Test(expected = NumberFormatException.class) public final void fromStringNFE() {
+		String s = "10.0,x,10.0";
+		Location.fromString(s);
+	}
+
+	@Test(expected = IndexOutOfBoundsException.class) public final void fromStringIOOBE() {
+		String s = "10.0,10.0";
+		Location.fromString(s);
 	}
 
 	@Test public final void depth() {
@@ -133,6 +137,10 @@ public class LocationTest {
 		assertTrue(locList.get(3) == l1);
 		assertTrue(locList.get(4) == l0);
 		assertTrue(locList.get(5) == l5);
+	}
+
+	public static void main(String[] args) {
+		Location loc = Location.fromString("10, 20, 30, 40");
 	}
 
 }

--- a/test/org/opensha2/geo/LocationsTest.java
+++ b/test/org/opensha2/geo/LocationsTest.java
@@ -1,0 +1,1596 @@
+package org.opensha2.geo;
+
+import static org.junit.Assert.*;
+
+import static org.opensha2.geo.GeoTools.EARTH_RADIUS_MEAN;
+import static org.opensha2.geo.GeoTools.TO_RAD;
+import static org.opensha2.geo.Locations.angle;
+import static org.opensha2.geo.Locations.areSimilar;
+import static org.opensha2.geo.Locations.azimuth;
+import static org.opensha2.geo.Locations.azimuthRad;
+import static org.opensha2.geo.Locations.distanceToLine;
+import static org.opensha2.geo.Locations.distanceToLineFast;
+import static org.opensha2.geo.Locations.distanceToSegment;
+import static org.opensha2.geo.Locations.distanceToSegmentFast;
+import static org.opensha2.geo.Locations.horzDistance;
+import static org.opensha2.geo.Locations.horzDistanceFast;
+import static org.opensha2.geo.Locations.isPole;
+import static org.opensha2.geo.Locations.linearDistance;
+import static org.opensha2.geo.Locations.linearDistanceFast;
+import static org.opensha2.geo.Locations.location;
+import static org.opensha2.geo.Locations.vertDistance;
+
+import java.util.ArrayList;
+import java.util.Random;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensha2.geo.Location;
+import org.opensha2.geo.LocationList;
+import org.opensha2.geo.Locations;
+import org.opensha2.geo.LocationVector;
+
+@SuppressWarnings("javadoc")
+public class LocationsTest {
+
+//	private static LocationList locs1, locs2;
+//	private static Location p1,p2,p3,p4,p5,p6,p7,p8,p9;
+//	
+//	private double result_p3p4_p8 = 78.62078721818267;
+//	private double result_p4_p8 = 111.19505230826488;
+//	private double result_p6p7_p9 = 78.55334545519592;
+//	private double result_p6_p9 = 111.04266335361307;
+//	
+//	@BeforeClass
+//	public static void setUp() {
+//		p1 = Location.create(-5,0);
+//		p2 = Location.create(-3,-2);
+//		p3 = Location.create(-2,-2);
+//		p4 = Location.create(0,0);
+//		p5 = Location.create(2,2);
+//		p6 = Location.create(3,2);
+//		p7 = Location.create(5,0);
+//		
+//		p8 = Location.create(-1,0);
+//		p9 = Location.create(3,1);
+//		
+//		locs1 = LocationList.create(p1,p2,p3,p4,p5,p6,p7);
+//		locs2 = LocationList.create(p1,p3,p2,p4,p6,p5,p7);
+//	}
+//
+//	/**
+//	 * @throws java.lang.Exception
+//	 */
+//	@BeforeClass public static void setUpBeforeClass() throws Exception {}
+//
+//	
+//	@Test
+//	public final void testMinDistToLocation() {
+//		assertEquals(result_p4_p8, ll1.minDistToLocation(p8), 0);
+//		assertEquals(result_p6_p9, ll1.minDistToLocation(p9), 0);
+//		assertEquals(
+//			Locations.horzDistanceFast(p6, p9),
+//			ll1.minDistToLocation(p9), 0);
+//		assertEquals(
+//			Locations.horzDistanceFast(p4, p8),
+//			ll1.minDistToLocation(p8), 0);
+//	}
+//
+//	@Test
+//	public final void testMinDistToLine() {
+//		assertEquals(result_p6p7_p9, ll1.minDistToLine(p9), 0);
+//		assertEquals(result_p3p4_p8, ll1.minDistToLine(p8), 0);
+//		// test against underlying distToSegment
+//		assertEquals(
+//			Locations.distanceToLineSegmentFast(p6, p7, p9), 
+//			ll1.minDistToLine(p9), 0);
+//		assertEquals(
+//			Locations.distanceToLineSegmentFast(p3, p4, p8), 
+//			ll1.minDistToLine(p8), 0);
+//	}
+	
+	// short-range, small-angle test points
+	private static Location L1 = Location.create(32.6, 20.4);
+	private static Location L2 = Location.create(32.4, 20);
+	private static Location L3 = Location.create(32.2, 20.6);
+	private static Location L4 = Location.create(32, 20.2, 10);
+	
+	// polar and long-distance, large-angle test points
+	private static Location L5 = Location.create(90, 0);
+	private static Location L6 = Location.create(-90, 0);
+	
+	// Expected results from methods in this class were computed using the
+	// class methods and compared to the results provided by one or more
+	// reputable online calculators.
+	
+	//    p2p: L1 to L2 eg
+	//     vd: Vincenty distance (most accurate, provided for comparison)
+	//     sd: expected values of surfaceDistance()
+	//    fsd: expected values of fastSurfaceDistance()
+	//  angle: in radians between points
+	// az-rad: azimuth in radians from L1 to L2
+	// az-deg: azimuth in degrees from L1 to L2
+	
+	// p2p	vd (km)		sd			fsd			angle		az-rad		az-deg
+	// ---	---------	---------	---------	-----------	-----------	---------
+	// d51	 6393.578	 6382.596	 6474.888	1.001818991	3.141592654	180.0
+	// d25	 6415.757	 6404.835	 6493.824	1.005309649	0.0			  0.0
+	// d46	13543.818	13565.796	13707.303	2.129301687	3.141592654	180.0
+	// d63	13565.996	13588.035	13735.216	2.132792346	0.0			  0.0
+	
+	// d12	43.645957	43.6090311	43.6090864  0.006844919 4.179125015 239.44623
+	// d13	48.183337	48.2790582	48.2790921	0.007577932	2.741190313 157.05864
+	// d14	69.150258	69.3145862	69.3146382	0.010879690 3.417161139 195.78891
+	// d23	60.706703	60.6198752	60.6200022	0.009514959	1.943625801 111.36156
+	// d42	48.198212	48.2952067	48.2952403	0.007580467	5.883856933	337.12017
+	// d43	43.787840	43.7518411	43.7518956	0.006867335	1.035735858  59.34329
+
+	//        fdtl           dtl
+	// d321   34.472999888   34.425229936
+	// d231   34.472999888  -34.425229936
+	// d432   47.859144611  -47.851004687
+	// d413   30.170948729   30.205855981
+
+	// deltas - based on what decimal place known values above were clipped
+	private static double ldD    = 0.001;		// long-distance
+	private static double sdD    = 0.0000001;	// short-distance
+	private static double angleD = 0.000000001;	// angle
+	private static double azrD   = 0.000000001;	// azimuth-rad
+	private static double azdD   = 0.00001;		// azimuth-deg
+	private static double dtlD   = 0.000000001;	// dist to line
+	
+
+//	@Test
+//	public final void testLocations() {
+//		// silly test of no arg private constructor
+//		try {
+//			Object obj = TestUtils.callPrivateNoArgConstructor(
+//					Locations.class);
+//		} catch (Exception e) {
+//			fail("Private no-arg constructor failed to initialize: " +
+//					e.getMessage());
+//		}
+//	}
+	
+	@Test
+	public final void testAngle() {
+		assertEquals(1.001818991, angle(L5,L1), angleD);
+		assertEquals(1.005309649, angle(L2,L5), angleD);
+		assertEquals(2.129301687, angle(L4,L6), angleD);
+		assertEquals(2.132792346, angle(L6,L3), angleD);
+		assertEquals(0.006844919, angle(L1,L2), angleD);
+		assertEquals(0.007577932, angle(L1,L3), angleD);
+		assertEquals(0.010879690, angle(L1,L4), angleD);
+		assertEquals(0.009514959, angle(L2,L3), angleD);
+		assertEquals(0.007580467, angle(L4,L2), angleD);
+		assertEquals(0.006867335, angle(L4,L3), angleD);
+	}
+
+	@Test
+	public final void testHorzDistance() {
+		assertEquals(6382.596, horzDistance(L5, L1), ldD);
+		assertEquals(6404.835, horzDistance(L2, L5), ldD);
+		assertEquals(13565.796, horzDistance(L4, L6), ldD);
+		assertEquals(13588.035, horzDistance(L6, L3), ldD);
+		assertEquals(43.6090311, horzDistance(L1, L2), sdD);
+		assertEquals(48.2790582, horzDistance(L1, L3), sdD);
+		assertEquals(69.3145862, horzDistance(L1, L4), sdD);
+		assertEquals(60.6198752, horzDistance(L2, L3), sdD);
+		assertEquals(48.2952067, horzDistance(L4, L2), sdD);
+		assertEquals(43.7518411, horzDistance(L4, L3), sdD);
+	}
+
+	// same locations, different reference frame
+	// distance between 1 and 2 should be the same as between 4 and 5
+	// P3 and P6 are used to test distanceToLineFast
+	private static Location P1 = Location.create(32.0, -160.0, 2.0);
+	private static Location P2 = Location.create(31.0, -163.0, 0.0);
+	private static Location P3 = Location.create(33.0, -164.0, 0.0);
+	private static Location P4 = Location.create(32.0,  200.0, 2.0);
+	private static Location P5 = Location.create(31.0,  197.0, 0.0);
+	private static Location P6 = Location.create(33.0,  196.0, 0.0);
+
+	@Test
+	public final void testHorzDistanceFast() {
+		assertEquals(  6474.888, horzDistanceFast(L5,L1), ldD);
+		assertEquals(  6493.824, horzDistanceFast(L2,L5), ldD);
+		assertEquals( 13707.303, horzDistanceFast(L4,L6), ldD);
+		assertEquals( 13735.216, horzDistanceFast(L6,L3), ldD);
+		assertEquals(43.6090864, horzDistanceFast(L1,L2), sdD);
+		assertEquals(48.2790921, horzDistanceFast(L1,L3), sdD);
+		assertEquals(69.3146382, horzDistanceFast(L1,L4), sdD);
+		assertEquals(60.6200022, horzDistanceFast(L2,L3), sdD);
+		assertEquals(48.2952403, horzDistanceFast(L4,L2), sdD);
+		assertEquals(43.7518956, horzDistanceFast(L4,L3), sdD);
+		
+		// test change to allow lon values up to 360
+		double original = horzDistanceFast(P1,  P2);
+		double updated = horzDistanceFast(P4,  P5);
+		assertEquals(original, updated, sdD);
+	}
+
+	@Test
+	public final void testVertDistance() {
+		Location L1 = Location.create( 23,  -32,  2);
+		Location L2 = Location.create(-12, -112, -2);
+		Location L3 = Location.create(-34,   86, 10);
+		assertEquals(-4, vertDistance(L1, L2), 0);
+		assertEquals( 8, vertDistance(L1, L3), 0);
+		assertEquals(12, vertDistance(L2, L3), 0);
+	}
+	
+	@Test
+	public final void testLinearDistance() {
+		double delta = 0.000000001;
+		
+		// small angles
+		Location L1 = Location.create(20.0, 20.0, 2);
+		Location L2 = Location.create(20.1, 20.1, 2);
+		Location L3 = Location.create(20.1, 20.1, 17);
+		double sd12 = horzDistance(L1,L2);	// 15.256270609
+		double ld12 = linearDistance(L1,L2);	// 15.251477684
+		double ld13 = linearDistance(L1,L3);	// 21.378955649
+		
+		assertTrue("Linear distance should be shorter", ld12 < sd12);
+		assertTrue("ld12 should be shorter than ld13", ld13 > ld12);
+		assertEquals(15.251477684, ld12, delta);
+		assertEquals(21.378955649, ld13, delta);
+
+		// large angles
+		Location L4 = Location.create( 45.0, -20.0, 2);
+		Location L5 = Location.create(-40.0, 20.0, 17);
+		Location L6 = Location.create(-50.0, 20.0, 17);
+		double ld45 = linearDistance(L4,L5);	// 9172.814801278
+		double ld46 = linearDistance(L4,L6);	// 9828.453361410
+		
+		assertEquals(9172.814801278, ld45, delta);
+		assertEquals(9828.453361410, ld46, delta);
+	}
+
+	@Test
+	public final void testLinearDistanceFast() {
+		double delta = 0.000000001;
+		
+		// small angles
+		Location L1 = Location.create(20.0, 20.0, 2);
+		Location L2 = Location.create(20.1, 20.1, 2);
+		Location L3 = Location.create(20.1, 20.1, 17);
+		double ld12 = linearDistanceFast(L1,L2);	// 15.256271986
+		double ld13 = linearDistanceFast(L1,L3);	// 21.395182516
+		assertEquals(15.256271986, ld12, delta);
+		assertEquals(21.395182516, ld13, delta);
+		
+		// test change to allow lon values up to 360
+		double original = linearDistanceFast(P1,  P2);
+		double updated = linearDistanceFast(P4,  P5);
+		assertEquals(original, updated, sdD);
+	}
+	
+	// additional locoations for line and segment tests
+	private static Location l1 = Location.create(2, 0);
+	private static Location l2 = Location.create(4, 0);
+
+	private static Location p1 = Location.create(1, 0);
+	private static Location p2 = Location.create(1, -1);
+	private static Location p3 = Location.create(3, -1);
+	private static Location p4 = Location.create(5, -1);
+	private static Location p5 = Location.create(5, 0);
+	private static Location p6 = Location.create(5, 1);
+	private static Location p7 = Location.create(3, 1);
+	private static Location p8 = Location.create(1, 1);
+
+	@Test
+	public final void testDistanceToLine() {
+		// set 1
+		assertEquals( 34.425229936, distanceToLine(L3,L2,L1), dtlD);
+		assertEquals(-34.425229936, distanceToLine(L2,L3,L1), dtlD);
+		assertEquals(-47.851004687, distanceToLine(L4,L3,L2), dtlD);
+		assertEquals( 30.205855981, distanceToLine(L4,L1,L3), dtlD);
+		//set 2
+		assertEquals(0.0, distanceToLine(l1, l2, p1), 0);
+		assertEquals(-111.17811504377568, distanceToLine(l1, l2, p2), 0);
+		assertEquals(-111.04264791008788, distanceToLine(l1, l2, p3), 0);
+		assertEquals(-110.77187883896175, distanceToLine(l1, l2, p4), 0);
+		assertEquals(0.0, distanceToLine(l1, l2, p5), 0);
+		assertEquals(110.7718788389617, distanceToLine(l1, l2, p6), 0);
+		assertEquals(111.04264791008788, distanceToLine(l1, l2, p7), 0);
+		assertEquals(111.17811504377575, distanceToLine(l1, l2, p8), 0);
+	}	
+	
+	@Test
+	public final void testDistanceToLineFast() {
+		//set 1
+		assertEquals( 34.472999888, distanceToLineFast(L3,L2,L1), dtlD);
+		assertEquals(-34.472999888, distanceToLineFast(L2,L3,L1), dtlD);
+		assertEquals(-47.859144611, distanceToLineFast(L4,L3,L2), dtlD);
+		assertEquals( 30.170948729, distanceToLineFast(L4,L1,L3), dtlD);
+		//set 2
+		assertEquals(0.0, distanceToLineFast(l1, l2, p1), 0);
+		assertEquals(-111.12731528678844, distanceToLineFast(l1, l2, p2), 0);
+		assertEquals(-111.04266335361307, distanceToLineFast(l1, l2, p3), 0);
+		assertEquals(-110.92418674948573, distanceToLineFast(l1, l2, p4), 0);
+		assertEquals(0.0, distanceToLineFast(l1, l2, p5), 0);
+		assertEquals(110.92418674948573, distanceToLineFast(l1, l2, p6), 0);
+		assertEquals(111.04266335361307, distanceToLineFast(l1, l2, p7), 0);
+		assertEquals(111.12731528678844, distanceToLineFast(l1, l2, p8), 0);
+		
+		// test change to allow lon values up to 360
+		double original = distanceToLineFast(P2, P3, P1);
+		double updated = distanceToLineFast(P5, P6, P4);
+		assertEquals(original, updated, sdD);
+	}
+	
+	@Test
+	public final void testDistanceToSegment() {
+		//set 1
+		assertEquals(34.425229936, distanceToSegment(L3,L2,L1), dtlD);
+		assertEquals(34.425229936, distanceToSegment(L2,L3,L1), dtlD);
+		assertEquals(47.851004687, distanceToSegment(L4,L3,L2), dtlD);
+		assertEquals(30.205855981, distanceToSegment(L4,L1,L3), dtlD);
+		//set 2
+		assertEquals(111.19505230826488, distanceToSegment(l1, l2, p1), 0);
+		assertEquals(157.22560972181338, distanceToSegment(l1, l2, p2), 0);
+		assertEquals(111.04264791008788, distanceToSegment(l1, l2, p3), 0);
+		assertEquals(157.0103400810619, distanceToSegment(l1, l2, p4), 0);
+		assertEquals(111.19505230826486, distanceToSegment(l1, l2, p5), 0);
+		assertEquals(157.0103400810619, distanceToSegment(l1, l2, p6), 0);
+		assertEquals(111.04264791008788, distanceToSegment(l1, l2, p7), 0);
+		assertEquals(157.22560972181338, distanceToSegment(l1, l2, p8), 0);
+	}
+	
+	@Test
+	public final void testDistanceToSegmentFast() {
+		//set 1
+		assertEquals(34.472999888, distanceToSegmentFast(L3,L2,L1), dtlD);
+		assertEquals(34.472999888, distanceToSegmentFast(L2,L3,L1), dtlD);
+		assertEquals(47.859144611, distanceToSegmentFast(L4,L3,L2), dtlD);
+		assertEquals(30.170948729, distanceToSegmentFast(L4,L1,L3), dtlD);
+		//set 2
+		assertEquals(111.19505230826488, distanceToSegmentFast(l1, l2, p1), 0);
+		assertEquals(157.2056610325692, distanceToSegmentFast(l1, l2, p2), 0);
+		assertEquals(111.04266335361307, distanceToSegmentFast(l1, l2, p3), 0);
+		assertEquals(157.0621369518209, distanceToSegmentFast(l1, l2, p4), 0);
+		assertEquals(111.19505230826486, distanceToSegmentFast(l1, l2, p5), 0);
+		assertEquals(157.0621369518209, distanceToSegmentFast(l1, l2, p6), 0);
+		assertEquals(111.04266335361307, distanceToSegmentFast(l1, l2, p7), 0);
+		assertEquals(157.2056610325692, distanceToSegmentFast(l1, l2, p8), 0);
+		
+		// test change to allow lon values up to 360
+		double original = distanceToSegmentFast(P2, P3, P1);
+		double updated = distanceToSegmentFast(P5, P6, P4);
+		assertEquals(original, updated, sdD);
+	}
+
+	@Test
+	public final void testAzimuth() {
+		assertEquals(    180.0, azimuth(L5,L1), azdD);
+		assertEquals(      0.0, azimuth(L2,L5), azdD);
+		assertEquals(    180.0, azimuth(L4,L6), azdD);
+		assertEquals(      0.0, azimuth(L6,L3), azdD);
+		assertEquals(239.44623, azimuth(L1,L2), azdD);
+		assertEquals(157.05864, azimuth(L1,L3), azdD);
+		assertEquals(195.78891, azimuth(L1,L4), azdD);
+		assertEquals(111.36156, azimuth(L2,L3), azdD);
+		assertEquals(337.12017, azimuth(L4,L2), azdD);
+		assertEquals( 59.34329, azimuth(L4,L3), azdD);
+	}
+
+	@Test
+	public final void testAzimuthRad() {
+		assertEquals(3.141592654, azimuthRad(L5,L1), azrD);
+		assertEquals(0.0        , azimuthRad(L2,L5), azrD);
+		assertEquals(3.141592654, azimuthRad(L4,L6), azrD);
+		assertEquals(0.0        , azimuthRad(L6,L3), azrD);
+		assertEquals(4.179125015, azimuthRad(L1,L2), azrD);
+		assertEquals(2.741190313, azimuthRad(L1,L3), azrD);
+		assertEquals(3.417161139, azimuthRad(L1,L4), azrD);
+		assertEquals(1.943625801, azimuthRad(L2,L3), azrD);
+		assertEquals(5.883856933, azimuthRad(L4,L2), azrD);
+		assertEquals(1.035735858, azimuthRad(L4,L3), azrD);
+	}
+
+	@Test
+	public final void testLocationLocationDoubleDouble() {
+		LocationVector d = LocationVector.create(L1,L2);
+		//TODO need to switch to getAzimuthRad
+		assertTrue(areSimilar(L2, location(
+				L1, d.azimuth(), d.horizontal())));
+		d = LocationVector.create(L1,L3);
+		assertTrue(areSimilar(L3, location(
+				L1, d.azimuth(), d.horizontal())));
+		d = LocationVector.create(L2,L3);
+		assertTrue(areSimilar(L3, location(
+				L2, d.azimuth(), d.horizontal())));
+	}
+	
+	@Test
+	public final void testLocationLocationDirection() {
+		assertTrue(areSimilar(L2, location(L1, LocationVector.create(L1,L2))));
+		assertTrue(areSimilar(L3, location(L1, LocationVector.create(L1,L3))));
+		assertTrue(areSimilar(L4, location(L1, LocationVector.create(L1,L4))));
+		assertTrue(areSimilar(L3, location(L2, LocationVector.create(L2,L3))));
+		assertTrue(areSimilar(L2, location(L4, LocationVector.create(L4,L2))));
+		assertTrue(areSimilar(L3, location(L4, LocationVector.create(L4,L3))));
+	}
+	
+	@Test
+	public final void testLocationVector() {
+		assertEquals(43.6090311, LocationVector.create(L1,L2).horizontal(), sdD);
+		assertEquals(48.2790582, LocationVector.create(L1,L3).horizontal(), sdD);
+		assertEquals(69.3145862, LocationVector.create(L1,L4).horizontal(), sdD);
+		assertEquals(60.6198752, LocationVector.create(L2,L3).horizontal(), sdD);
+		assertEquals(48.2952067, LocationVector.create(L4,L2).horizontal(), sdD);
+		assertEquals(43.7518411, LocationVector.create(L4,L3).horizontal(), sdD);
+
+		// TODO these will need to be replaced with azimuthRad()
+		assertEquals(239.44623, LocationVector.create(L1,L2).azimuthDegrees(), azdD);
+		assertEquals(157.05864, LocationVector.create(L1,L3).azimuthDegrees(), azdD);
+		assertEquals(195.78891, LocationVector.create(L1,L4).azimuthDegrees(), azdD);
+		assertEquals(111.36156, LocationVector.create(L2,L3).azimuthDegrees(), azdD);
+		assertEquals(337.12017, LocationVector.create(L4,L2).azimuthDegrees(), azdD);
+		assertEquals( 59.34329, LocationVector.create(L4,L3).azimuthDegrees(), azdD);
+
+		assertEquals(  0, LocationVector.create(L1,L2).vertical(), 0);
+		assertEquals(  0, LocationVector.create(L1,L3).vertical(), 0);
+		assertEquals( 10, LocationVector.create(L1,L4).vertical(), 0);
+		assertEquals(  0, LocationVector.create(L2,L3).vertical(), 0);
+		assertEquals(-10, LocationVector.create(L4,L2).vertical(), 0);
+		assertEquals(-10, LocationVector.create(L4,L3).vertical(), 0);
+		
+		// reverse tests
+		Location L1 = Location.create(20.0, 20.0, 0);
+		Location L2 = Location.create(20.1, 20.1, 2);
+		LocationVector v = LocationVector.create(L1,L2);
+		double az = v.azimuthDegrees();
+		double dv = v.vertical();
+		LocationVector vr = LocationVector.reverseOf(v);
+		assertEquals((az + 180) % 360, vr.azimuthDegrees(), 0);
+		assertEquals(-dv, vr.vertical(), 0);
+		
+		// test plunge
+		LocationVector vPlunge = LocationVector.create(0.0, 2, 2);
+		assertEquals(45.0, vPlunge.plungeDegrees(), 0.0);
+		vPlunge = LocationVector.create(0.0, 2, -2);
+		assertEquals(-45.0, vPlunge.plungeDegrees(), 0.0);
+		
+	}
+	
+	@Test
+	public final void testBisect() {
+		double tol = 0.000000000001;
+		Location p1, p2, p3;
+		LocationVector p2p1, p2p3, vTest;
+
+		// general case
+		p2 = Location.create(20,20);
+		p2p1 = LocationVector.create(220 * TO_RAD, 100, 0);
+		p1 = Locations.location(p2,  p2p1);
+		p2p3 = LocationVector.create(90 * TO_RAD, 100, 0);
+		p3 = Locations.location(p2,  p2p3);
+		vTest = Locations.bisect(p1, p2, p3);
+		assertEquals(155, vTest.azimuthDegrees(), tol);
+		
+		// 4th quadrant 270-360
+		p2p1 = LocationVector.create(320 * TO_RAD, 100, 0);
+		p1 = Locations.location(p2,  p2p1);
+		p2p3 = LocationVector.create(20 * TO_RAD, 100, 0);
+		p3 = Locations.location(p2,  p2p3);
+		vTest = Locations.bisect(p1, p2, p3);
+		assertEquals(170, vTest.azimuthDegrees(), tol);
+
+		// p1 & p3 coincident
+		p2p1 = LocationVector.create(90 * TO_RAD, 100, 0);
+		p1 = Locations.location(p2,  p2p1);
+		p2p3 = LocationVector.create(90 * TO_RAD, 100, 0);
+		p3 = Locations.location(p2,  p2p3);
+		vTest = Locations.bisect(p1, p2, p3);
+		assertEquals(90, vTest.azimuthDegrees(), tol);
+
+		// p1, p2, & p3 coincident
+		vTest = Locations.bisect(p2, p2, p2);
+		assertEquals(0, vTest.azimuthDegrees(), tol);
+	}
+	
+	@Test
+	public final void testIsPole() {
+		Location sp = Location.create(-89.999999999999, 0);
+		Location np = Location.create( 89.999999999999, 0);
+		Location ll = Location.create(22,150);
+		assertTrue(isPole(sp));
+		assertTrue(isPole(np));
+		assertTrue(!isPole(ll));
+	}
+	
+	@Test
+	public final void testAreSimilar() {
+		// NOTE the generic tolerance of 0.000000000001 in Locations imposes
+		// different magnitude constraints on depth vs. lat lon
+		Location p1, p2;
+		// compare lats
+		p1 = Location.create(30,0,0);
+		p2 = Location.create(30.00000000001,0,0);
+		assertTrue(areSimilar(p1, p2));
+		p2 = Location.create(30.0000000001,0,0);
+		assertTrue(!areSimilar(p1, p2));
+		// compare lons
+		p1 = Location.create(0,-30.0,0);
+		p2 = Location.create(0,-30.00000000001,0);
+		assertTrue(areSimilar(p1, p2));
+		p2 = Location.create(0,-30.0000000001,0);
+		assertTrue(!areSimilar(p1, p2));
+		// compare depths
+		p1 = Location.create(0,0,5.0);
+		p2 = Location.create(0,0,5.0000000000001);
+		assertTrue(areSimilar(p1, p2));
+		p2 = Location.create(0,0,5.000000000001);
+		assertTrue(!areSimilar(p1, p2));
+	}
+	
+	
+	/**
+	 * DEVELOPER NOTE
+	 * 
+	 * Test value generation along with various speed comparisons 
+	 * provided below. Speed tests can be run with fixed or randomized
+	 * values; randomization generally only adds a set amount of time
+	 * to each test.
+	 * 
+	 * Internal methods marked with *OLD were removed intact from
+	 * Locations to preserve history and preserve ability to document
+	 * performance enhancements.
+	 */
+	public static void main(String[] args) {
+				
+		// shared convenience fields
+		Location L1, L2, L3, L4, L5, L6;
+		int numIter = 1000000;
+		
+		// flag for using fixed (vs random) values in speed tests
+		boolean fixedVals = true;
+		
+		
+		
+		// ==========================================================
+		//     VALUE GENERATION
+		// ==========================================================
+		
+		L1 = Location.create(32.6, 20.4);
+		L2 = Location.create(32.4, 20);
+		L3 = Location.create(32.2, 20.6);
+		L4 = Location.create(32, 20.2, 10);
+		
+		L5 = Location.create(90, 0);
+		L6 = Location.create(-90, 0);
+		
+		//     vd			sd			fsd			angle		az-rad		az-deg
+		// d51  6393.578 km	 6382.596	 6474.888	1.001818991	3.141592654	180.0
+		// d25  6415.757 km	 6404.835	 6493.824	1.005309649	0.0			  0.0
+		// d46 13543.818 km	13565.796	13707.303	2.129301687	3.141592654	180.0
+		// d63 13565.996 km	13588.035	13735.216	2.132792346	0.0			  0.0
+		
+		// d12 43.645957 km	43.6090311	43.6090864  0.006844919 4.179125015 239.44623
+		// d13 48.183337 km	48.2790582	48.2790921	0.007577932	2.741190313 157.05864
+		// d14 69.150258 km	69.3145862	69.3146382	0.010879690 3.417161139 195.78891
+		// d23 60.706703 km	60.6198752	60.6200022	0.009514959	1.943625801 111.36156
+		// d42 48.198212 km	48.2952067	48.2952403	0.007580467	5.883856933	337.12017
+		// d43 43.787840 km	43.7518411	43.7518956	0.006867335	1.035735858  59.34329
+		
+		//        fdtl           dtl
+		// d321   34.472999888   34.425229936
+		// d231   34.472999888  -34.425229936
+		// d432   47.859144611  -47.851004687
+		// d413   30.170948729   30.205855981
+		
+		Location p1 = L1;
+		Location p2 = L2;
+		Location p3 = L3;
+		System.out.println(horzDistance(p1, p2));
+		System.out.println(horzDistanceFast(p1, p2));
+		System.out.println(angle(p1,p2));
+		System.out.println(azimuthRad(p1, p2));
+		System.out.println(azimuth(p1, p2));
+		System.out.println(distanceToLineFast(p1, p2, p3));
+		System.out.println(distanceToLine(p1, p2, p3));
+		
+		
+		
+		
+		// ==========================================================
+		//    Distance to Line Methods
+		//
+		//    Summary: the highly accurate Haversine based formula is 
+		//             much slower (up to 20x), but does not work
+		//			   accross dateline and does not indicate
+		//			   sidedness.
+		//             1M repeat runs showed the following comp
+		//             times for fixed location pairs:
+		//
+		//             DTL		distanceToLine()			1600 ms
+		//             DTLFo	distanceToLineFastOLD()		120 ms
+		//             DTLF		distanceToLineFast()		1 ms
+		//             DTS		distanceToSegment()			1 ms
+		//             DTSF		distanceToSegmentFast()		1 ms
+		//
+		//
+		// ==========================================================
+		
+		L2 = Location.create(32,-116);
+		L1 = Location.create(37,-115);
+		L3 = Location.create(34,-114);
+		
+		System.out.println("\nSPEED TEST -- Distance to Line\n");
+		System.out.println("distanceToLine(): " + 
+			distanceToLine(L1,L2,L3));
+		for (int i=0; i < 5; i++) {
+			long T = System.currentTimeMillis();
+			double d;
+			for (int j=0; j<numIter; j++) {
+				d = (fixedVals) ? 
+						distanceToLine(L1,L2,L3) :
+						distanceToLine(randomLoc(),randomLoc(),randomLoc());
+			}
+			T = (System.currentTimeMillis() - T);
+			System.out.println("    DTL: " + T);
+		}
+
+		System.out.println("distToLineFastOLD(): " + 
+			distanceToLineFastOLD(L1,L2,L3));
+		for (int i=0; i < 5; i++) {
+			long T = System.currentTimeMillis();
+			double d;
+			for (int j=0; j<numIter; j++) {
+				d = (fixedVals) ? 
+					distanceToLineFastOLD(L1,L2,L3) :
+						distanceToLineFastOLD(
+								randomLoc(),randomLoc(),randomLoc());
+			}
+			T = (System.currentTimeMillis() - T);
+			System.out.println("  DTLFo: " + T);
+		}
+		
+		System.out.println("distanceToLineFast(): " + 
+			distanceToLineFast(L1,L2,L3));
+		for (int i=0; i < 5; i++) {
+			long T = System.currentTimeMillis();
+			double d;
+			for (int j=0; j<numIter; j++) {
+				d = (fixedVals) ? 
+					distanceToLineFast(L1,L2,L3) :
+						distanceToLineFast(randomLoc(),randomLoc(),randomLoc());
+			}
+			T = (System.currentTimeMillis() - T);
+			System.out.println("   DTLF: " + T);
+		}
+
+		System.out.println("distanceToSegment(): " + 
+			distanceToSegment(L1,L2,L3));
+		for (int i=0; i < 5; i++) {
+			long T = System.currentTimeMillis();
+			double d;
+			for (int j=0; j<numIter; j++) {
+				d = (fixedVals) ? 
+					distanceToSegment(L1,L2,L3) :
+						distanceToSegment(randomLoc(),randomLoc(),randomLoc());
+			}
+			T = (System.currentTimeMillis() - T);
+			System.out.println("    DTS: " + T);
+		}
+		
+		System.out.println("distanceToSegmentFast(): " + 
+			distanceToSegmentFast(L1,L2,L3));
+		for (int i=0; i < 5; i++) {
+			long T = System.currentTimeMillis();
+			double d;
+			for (int j=0; j<numIter; j++) {
+				d = (fixedVals) ? 
+					distanceToSegmentFast(L1,L2,L3) :
+						distanceToSegmentFast(randomLoc(),randomLoc(),randomLoc());
+			}
+			T = (System.currentTimeMillis() - T);
+			System.out.println("   DTSF: " + T);
+		}
+		
+		
+//		// ==========================================================
+//		//    Horizontal (Surface) Distance Methods
+//		//
+//		//    Summary: Accurate, Haversine based methods of distance
+//		//             calculation have beeen shown to be much faster
+//		//             than existing methods (e.g. getHorzDistance).
+//		//             1M repeat runs showed the following comp
+//		//             times for fixed location pairs:
+//		//                
+//		//             HDo   getHorizDistanceOLD()		1285 ms
+//		//             AHDo  getApproxHorzDistanceOLD()	955  ms
+//		//             HD   horzDistance()				230  ms
+//		//             HDF  horzDistanceFast()			1    ms
+//		// ==========================================================
+//
+//		// long pair ~9K km : discrepancies > 100km
+//		// L1 = new Location(20,-10);
+//		// L2 = new Location(-20,60);
+//		
+//		// mid pair ~250 km : discrepancies in 10s of meters
+//		// L1 = new Location(32.1,-117.2);
+//		// L2 = new Location(33.8, -115.4);
+//		
+//		// short pair : negligible discrepancy in values
+//		L1 = new Location(32.132,-117.21);
+//		L2 = new Location(32.306, -117.105);
+//		
+//		System.out.println("\nSPEED TEST -- Horizontal Distance\n");
+//		System.out.println("getHorzDistanceOLD(): " + 
+//				getHorzDistanceOLD(L1, L2));
+//		for (int i=0; i < 5; i++) {
+//			long T = System.currentTimeMillis();
+//			double d;
+//			for (int j=0; j<numIter; j++) {
+//				d = (fixedVals) ? 
+//						getHorzDistanceOLD(L1, L2) :
+//						getHorzDistanceOLD(randomLoc(),randomLoc());
+//			}
+//			T = (System.currentTimeMillis() - T);
+//			System.out.println("   HDo: " + T);
+//		}
+//		
+//		System.out.println("getApproxHorzDistanceOLD(): " + 
+//				getApproxHorzDistanceOLD(L1, L2));
+//		for (int i=0; i < 5; i++) {
+//			long T = System.currentTimeMillis();
+//			double d;
+//			for (int j=0; j<numIter; j++) {
+//				d = (fixedVals) ? 
+//						getApproxHorzDistanceOLD(L1, L2) :
+//						getApproxHorzDistanceOLD(randomLoc(),randomLoc());
+//			}
+//			T = (System.currentTimeMillis() - T);
+//			System.out.println("   ADo: " + T);
+//		}
+//
+//		System.out.println("horzDistance(): " + 
+//				horzDistance(L1, L2));
+//		for (int i=0; i < 5; i++) {
+//			long T = System.currentTimeMillis();
+//			double d;
+//			for (int j=0; j<numIter; j++) {
+//				d = (fixedVals) ? 
+//						horzDistance(L1, L2) :
+//						horzDistance(randomLoc(),randomLoc());
+//			}
+//			T = (System.currentTimeMillis() - T);
+//			System.out.println("   HD: " + T);
+//		}
+//		
+//		System.out.println("horzDistanceFast(): " + 
+//				horzDistanceFast(L1, L2));
+//		for (int i=0; i < 5; i++) {
+//			long T = System.currentTimeMillis();
+//			double d;
+//			for (int j=0; j<numIter; j++) {
+//				d = (fixedVals) ? 
+//						horzDistanceFast(L1, L2) :
+//						horzDistanceFast(randomLoc(),randomLoc());
+//			}
+//			T = (System.currentTimeMillis() - T);
+//			System.out.println("   HDF: " + T);
+//		}
+//
+//		
+//		
+//
+//		// ==========================================================
+//		//    Linear Distance Methods
+//		//
+//		//    Summary: Accurate, Haversine based methods of distance
+//		//             calculation have beeen shown to be much faster
+//		//             than existing methods (e.g. getHorzDistance).
+//		//             1M repeat runs showed the following comp
+//		//             times for fixed location pairs:
+//		//                
+//		//             TDo   getTotalDistanceOLD()		1300 ms
+//		//             LD   linearDistance()			240  ms
+//		//             LDF  linearDistanceFast()		1    ms
+//		// ==========================================================
+//
+//		// mid pair ~250 km : discrepancies in 10s of meters
+//		L1 = new Location(32.1,-117.2);
+//		L2 = new Location(33.8, -115.4);
+//		
+//		// short pair : negligible discrepancy in values
+//		// L1 = new Location(32.132,-117.21);
+//		// L2 = new Location(32.306, -117.105);
+//		
+//		System.out.println("\nSPEED TEST -- Linear Distance\n");
+//		System.out.println("getTotalDistanceOLD(): " + 
+//				getTotalDistanceOLD(L1, L2));
+//		for (int i=0; i < 5; i++) {
+//			long T = System.currentTimeMillis();
+//			double d;
+//			for (int j=0; j<numIter; j++) {
+//				d = (fixedVals) ? 
+//						getTotalDistanceOLD(L1, L2) :
+//						getTotalDistanceOLD(randomLoc(),randomLoc());
+//			}
+//			T = (System.currentTimeMillis() - T);
+//			System.out.println("   TDo: " + T);
+//		}
+//
+//		System.out.println("linearDistance(): " + 
+//				linearDistance(L1, L2));
+//		for (int i=0; i < 5; i++) {
+//			long T = System.currentTimeMillis();
+//			double d;
+//			for (int j=0; j<numIter; j++) {
+//				d = (fixedVals) ? 
+//						linearDistance(L1, L2) :
+//						linearDistance(randomLoc(),randomLoc());
+//			}
+//			T = (System.currentTimeMillis() - T);
+//			System.out.println("    LD: " + T);
+//		}
+//		
+//		System.out.println("linearDistanceFast(): " + 
+//				linearDistanceFast(L1, L2));
+//		for (int i=0; i < 5; i++) {
+//			long T = System.currentTimeMillis();
+//			double d;
+//			for (int j=0; j<numIter; j++) {
+//				d = (fixedVals) ? 
+//						linearDistanceFast(L1, L2) :
+//						linearDistanceFast(randomLoc(),randomLoc());
+//			}
+//			T = (System.currentTimeMillis() - T);
+//			System.out.println("   LDF: " + T);
+//		}
+//
+//		
+//		
+//		// ==========================================================
+//		//    Azimuth Methods
+//		//
+//		//    Summary: New, spherical geometry azimuth methods are
+//		//			   faster than existing methods.
+//		//             1M repeat runs showed the following comp
+//		//             times for fixed location pairs:
+//		//                
+//		//             gAo   getAzimuthOLD()		1240 ms
+//		//             A   azimuth()				348  ms
+//		// ==========================================================
+//
+//		L1 = new Location(32, -117);
+//		L2 = new Location(33, -115);
+//		
+//		System.out.println("\nSPEED TEST -- Azimuth\n");
+//		System.out.println("getAzimuthOLD(): " + 
+//				getAzimuthOLD(L1, L2));
+//		for (int i=0; i < 5; i++) {
+//			long T = System.currentTimeMillis();
+//			double d;
+//			for (int j=0; j<numIter; j++) {
+//				d = (fixedVals) ? 
+//						getAzimuthOLD(L1, L2) :
+//						getAzimuthOLD(randomLoc(),randomLoc());
+//			}
+//			T = (System.currentTimeMillis() - T);
+//			System.out.println("   gAo: " + T);
+//		}
+//
+//		System.out.println("azimuth(): " + 
+//				azimuth(L1, L2));
+//		for (int i=0; i < 5; i++) {
+//			long T = System.currentTimeMillis();
+//			double d;
+//			for (int j=0; j<numIter; j++) {
+//				d = (fixedVals) ? 
+//						azimuth(L1, L2) :
+//						azimuth(randomLoc(),randomLoc());
+//			}
+//			T = (System.currentTimeMillis() - T);
+//			System.out.println("     A: " + T);
+//		}
+//
+//		
+//		
+//		
+//		// ==========================================================
+//		//    Vector Methods
+//		//
+//		//    Summary: New, spherical geometry direction methods are
+//		//			   faster than existing methods. A test using
+//		//			   horzDistanceFast instead of horzDistance 
+//		//			   realized no speed gain.
+//		//             1M repeat runs showed the following comp
+//		//             times for fixed location pairs:
+//		//                
+//		//             gDo		getDirectionOLD()		3700 ms
+//		//             V		vector()				610  ms
+//		// ==========================================================
+//
+//		L1 = new Location(32, -117);
+//		L2 = new Location(33, -115);
+//		
+//		System.out.println("\nSPEED TEST -- LocationVector\n");
+//		System.out.println("getDirectionOLD(): " + getDirectionOLD(L1, L2));
+//		for (int i=0; i < 5; i++) {
+//			long T = System.currentTimeMillis();
+//			LocationVector d;
+//			for (int j=0; j<numIter; j++) {
+//				d = (fixedVals) ? 
+//						getDirectionOLD(L1, L2) :
+//						getDirectionOLD(randomLoc(),randomLoc());
+//			}
+//			T = (System.currentTimeMillis() - T);
+//			System.out.println("    gDo: " + T);
+//		}
+//
+//		System.out.println("vector(): " + vector(L1, L2));
+//		for (int i=0; i < 5; i++) {
+//			long T = System.currentTimeMillis();
+//			LocationVector d;
+//			for (int j=0; j<numIter; j++) {
+//				d = (fixedVals) ? 
+//						vector(L1, L2) :
+//						vector(randomLoc(),randomLoc());
+//			}
+//			T = (System.currentTimeMillis() - T);
+//			System.out.println("     V: " + T);
+//		}
+//
+//
+//		
+//		// ==========================================================
+//		//    Location Methods
+//		//
+//		//    Summary: New, spherical geometry direction methods are
+//		//			   slightly faster than existing methods.
+//		//             1M repeat runs showed the following comp
+//		//             times for fixed location pairs:
+//		//                
+//		//             gLo		getLocationOLD()	915  ms
+//		//             L		location()			670  ms
+//		// ==========================================================
+//
+//		L1 = new Location(32, -117);
+//		L2 = new Location(33, -115);
+//		LocationVector dir = new LocationVector(20,111,10);
+//		System.out.println("\nSPEED TEST -- Location\n");
+//		System.out.println("getLocationOLD(): " + getLocationOLD(L1, dir));
+//		for (int i=0; i < 5; i++) {
+//			long T = System.currentTimeMillis();
+//			Location loc;
+//			for (int j=0; j<numIter; j++) {
+//				loc = (fixedVals) ? 
+//						getLocationOLD(L1, dir) :
+//						getLocationOLD(randomLoc(),dir);
+//			}
+//			T = (System.currentTimeMillis() - T);
+//			System.out.println("    gL: " + T);
+//		}
+//
+//		System.out.println("location(): " + location(L1, dir));
+//		for (int i=0; i < 5; i++) {
+//			long T = System.currentTimeMillis();
+//			Location loc;
+//			for (int j=0; j<numIter; j++) {
+//				loc = (fixedVals) ? 
+//						location(L1, dir) :
+//						location(randomLoc(),dir);
+//			}
+//			T = (System.currentTimeMillis() - T);
+//			System.out.println("     L: " + T);
+//		}
+//
+//		
+//		
+//		// ==========================================================
+//		//    The following code may be used to explore how old and
+//		//	  new distance caclulation methods compare and how
+//		//	  results cary with distance
+//		// ==========================================================
+//
+//		// commented values are accurate distances computed 
+//		// using the Vincenty formula
+//		
+//		Location L1a = new Location(20,-10); // 8818.496 km
+//		Location L1b = new Location(-20,60);
+//		
+//		Location L2a = new Location(90,10); // 4461.118 km
+//		Location L2b = new Location(50,80);
+//
+//		Location L3a = new Location(-80,-30); // 3824.063 km
+//		Location L3b = new Location(-50,20);
+//		
+//		Location L4a = new Location(-42,178); // 560.148 km
+//		Location L4b = new Location(-38,-178);
+//
+//		Location L5a = new Location(5,-90); // 784.028 km
+//		Location L5b = new Location(0,-85);
+//
+//		Location L6a = new Location(70,-40); // 1148.942 km
+//		Location L6b = new Location(80,-50);
+//
+//		Location L7a = new Location(-30,80); // 1497.148 km
+//		Location L7b = new Location(-20,90);
+//		
+//		Location L8a = new Location(70,70); // 234.662 km
+//		Location L8b = new Location(72,72);
+//
+//		Location L9a = new Location(-20,120); // 305.532 km
+//		Location L9b = new Location(-18,122);
+//		
+//		// LocationList llL1 = createLocList(L1a,L1b,0.2);
+//		// LocationList llL2 = createLocList(L2a,L2b,0.2);
+//		// LocationList llL3 = createLocList(L3a,L3b,0.2);
+//		// LocationList llL4 = createLocList(L4a,L4b,356); // spans prime meridian
+//		LocationList llL5 = createLocList(L5a,L5b,0.05);
+//		// LocationList llL6 = createLocList(L6a,L6b,0.05);
+//		// LocationList llL7 = createLocList(L7a,L7b,0.05);
+//		// LocationList llL8 = createLocList(L8a,L8b,0.001);
+//		// LocationList llL9 = createLocList(L9a,L9b,0.001);
+//		
+//		LocationList LLtoUse = llL5;
+//		Location startPt = LLtoUse.get(0);
+//		for (int i = 1; i < LLtoUse.size(); i++) {
+//			Location endPt = LLtoUse.get(i);
+//			double surfDist = horzDistance(startPt, endPt);
+//			double fastSurfDist = horzDistanceFast(startPt, endPt);
+//			double delta1 = fastSurfDist - surfDist;
+//			double horizDist = getHorzDistanceOLD(startPt, endPt);
+//			double approxDist = getApproxHorzDistanceOLD(startPt, endPt);
+//			double delta2 = approxDist - horizDist;
+//			double delta3 = fastSurfDist - approxDist;
+//			String s = String.format(
+//					"sd: %03.4f  sdf: %03.4f  d: %03.4f  " + 
+//					"hdO: %03.4f  adO: %03.4f  d: %03.4f  Df: %03.4f",
+//					surfDist, fastSurfDist, delta1,
+//					horizDist, approxDist, delta2, delta3);
+//			System.out.println(s);
+//		}
+//	
+	}
+	
+	// utility method to create a locationlist between two points; points
+	// are discretized in longitude using 'lonInterval'; latitude intervals 
+	// are whatever they need to be to get to L2
+	//
+	// this is used in 'main' when exploring variations between distance
+	// calculators
+	private static LocationList createLocList(
+			Location L1, Location L2, double lonInterval) {
+		int numPoints = (int) Math.floor(Math.abs(
+				L2.lon() - L1.lon()) / lonInterval);
+		double dLat = (L2.lat() - L1.lat()) / numPoints;
+		double dLon = (L1.lon() - L2.lon() < 0) ? 
+				lonInterval : -lonInterval;
+		LocationList.Builder llb = LocationList.builder();
+		double lat = L1.lat();
+		double lon = L1.lon();
+		for(int i=0; i<=numPoints; i++) {
+			//System.out.println(lat + " " + lon);
+			llb.add(Location.create(lat,lon));
+			lat += dLat;
+			lon += dLon;
+		}
+		return llb.build();
+	}
+
+	// utility method to generate random locations within +/- 40deg lat and 
+	// +/- 40 deg lon
+	private static Random rand = new Random();
+	private static Location randomLoc() {
+		return Location.create(randLatLon(), randLatLon());
+	}
+	private static double randLatLon() {
+		return (rand.nextDouble() * 80) - 40;
+	}
+	
+	// ==========================================================
+	// 					ARCHIVED METHODS
+	// ==========================================================
+
+	/** Earth radius constant */
+	private final static int R = 6367;
+
+	/** Radians to degrees conversion constant */
+	private final static double RADIANS_CONVERSION = Math.PI / 180;
+
+	/** Degree to Km conversion at equator */
+	private final static double D_COEFF = 111.11;
+
+	/**
+	 * OLD METHOD
+	 */
+	private static double getHorzDistanceOLD(Location loc1, Location loc2) {
+		return getHorzDistanceOLD(
+				loc1.lat(), loc1.lon(),
+				loc2.lat(), loc2.lon());
+	}
+	
+	/**
+	 * OLD METHOD
+	 * 
+	 * Second way to calculate the distance between two points. Obtained 
+	 * off the internet, but forgot where now. When used in comparision with
+	 * the latLonDistance function you see they give practically the same 
+	 * values at the equator, and only start to diverge near the
+	 * poles, but still reasonable close to each other. Good for point 
+	 * of comparision.
+	 */
+	private static double getHorzDistanceOLD(
+			double lat1, double lon1, double lat2, double lon2 ){
+
+		double xlat = lat1 * RADIANS_CONVERSION;
+		double xlon = lon1 * RADIANS_CONVERSION;
+
+		double st0 = Math.cos( xlat );
+		double ct0 = Math.sin( xlat );
+
+		double phi0 = xlon;
+
+		xlat = lat2 * RADIANS_CONVERSION;
+		xlon = lon2 * RADIANS_CONVERSION;
+
+		double st1 = Math.cos(xlat);
+		double ct1 = Math.sin(xlat);
+
+
+		double sdlon = Math.sin( xlon - phi0);
+		double cdlon = Math.cos( xlon - phi0);
+
+		double cdelt = ( st0 * st1 * cdlon ) + ( ct0 * ct1 );
+
+		double x = ( st0 * ct1 ) - ( st1 * ct0 * cdlon );
+		double y = st1 * sdlon;
+
+		double sdelt=  Math.pow( ( ( x * x ) + ( y * y ) ), .5 );
+		double delta = Math.atan2( sdelt, cdelt ) / RADIANS_CONVERSION;
+
+		delta = delta * D_COEFF;
+
+		return delta;
+	}
+	
+	/**
+	 * OLD METHOD
+	 */
+	private static double getApproxHorzDistanceOLD(
+			Location loc1, Location loc2) {
+		return getApproxHorzDistanceOLD(
+				loc1.lat(), loc1.lon(), 
+				loc2.lat(), loc2.lon());
+	}
+
+	/**
+	 * OLD METHOD
+	 * 
+	 * This computes the approximate horizontal distance (in km) using
+	 * the standard cartesian coordinate transformation.  Not implemented 
+	 * correctly is lons straddle 360 or 0 degrees!
+	 */
+	private static double getApproxHorzDistanceOLD(
+			double lat1, double lon1, double lat2, double lon2 ){
+	  double d1 = (lat1-lat2)*111.111;
+	  double d2 = (lon1-lon2)*111.111*Math.cos(((lat1+lat2)/(2))*Math.PI/180);
+	  return Math.sqrt(d1*d1+d2*d2);
+	}
+
+	/**
+	 * OLD METHOD
+	 * 
+	 * Helper method that calculates the angle between two locations
+	 * on the earth.<p>
+	 *
+	 * @param loc1			   location of first point
+	 * @param loc2			   location of second point
+	 * @return				  angle between the two locations
+	 */
+	private static double getAzimuthOLD( Location loc1, Location loc2 ){
+	  return getAzimuthOLD( loc1.lat(), loc1.lon(),
+						 loc2.lat(), loc2.lon() );
+	}
+
+	/**
+	 * OLD METHOD
+	 * 
+	 * Helper method that calculates the angle between two locations 
+	 * (value returned is between -180 and 180 degrees)
+	 * on the earth.<p>
+	 *
+	 * @param lat1			   latitude of first point
+	 * @param lon1			   longitude of first point
+	 * @param lat2			   latitude of second point
+	 * @param lon2			   longitude of second point
+	 * @return				  angle between the two lat/lon locations
+	 */
+	private static double getAzimuthOLD(
+			double lat1, double lon1, double lat2, double lon2 ){
+
+		double xlat = lat1 * RADIANS_CONVERSION;
+		double xlon = lon1 * RADIANS_CONVERSION;
+
+		double st0 = Math.cos( xlat );
+		double ct0 = Math.sin( xlat );
+
+		double phi0 = xlon;
+
+		xlat = lat2 * RADIANS_CONVERSION;
+		xlon = lon2 * RADIANS_CONVERSION;
+
+		double st1 = Math.cos(xlat);
+		double ct1 = Math.sin(xlat);
+
+		double sdlon = Math.sin( xlon - phi0);
+		double cdlon = Math.cos( xlon - phi0);
+
+		double x = ( st0 * ct1 ) - ( st1 * ct0 * cdlon );
+		double y = st1 * sdlon;
+
+		double az = Math.atan2( y, x ) / RADIANS_CONVERSION;
+
+		return az;
+	}
+
+	/**
+	 * OLD METHOD
+	 * 
+	 * Helper method that calculates the angle between two locations
+	 * on the earth.<p>
+	 *
+	 * Note: SWR: I'm not quite sure of the difference between azimuth and
+	 * back azimuth. Ned, you will have to fill in the details.
+	 *
+	 * @param lat1			   latitude of first point
+	 * @param lon1			   longitude of first point
+	 * @param lat2			   latitude of second point
+	 * @param lon2			   longitude of second point
+	 * @return				  angle between the two lat/lon locations
+	 */
+	private static double getBackAzimuthOLD(
+			double lat1, double lon1, double lat2, double lon2 ){
+
+		double xlat = lat1 * RADIANS_CONVERSION;
+		double xlon = lon1 * RADIANS_CONVERSION;
+
+		double st0 = Math.cos( xlat );
+		double ct0 = Math.sin( xlat );
+
+		double phi0 = xlon;
+
+		xlat = lat2 * RADIANS_CONVERSION;
+		xlon = lon2 * RADIANS_CONVERSION;
+
+		double st1 = Math.cos(xlat);
+		double ct1 = Math.sin(xlat);
+
+		double sdlon = Math.sin( xlon - phi0);
+		double cdlon = Math.cos( xlon - phi0);
+
+		double x = ( st1 * ct0 ) - ( st0 * ct1 * cdlon );
+		double y = -sdlon * st0;
+
+		double baz = Math.atan2( y, x ) / RADIANS_CONVERSION;
+
+		return baz;
+	}
+
+	/**
+	 * OLD METHOD
+	 * 
+	 * This computes the total distance in km.
+	 */
+	private static double getTotalDistanceOLD(Location loc1, Location loc2) {
+		double hDist = getHorzDistanceOLD(loc1, loc2);
+		double vDist = vertDistance(loc1, loc2);
+		return  Math.sqrt(hDist*hDist+vDist*vDist);
+	}
+	
+	/**
+	 * OLD METHOD
+	 * 
+	 *  Given a Location and a LocationVector object, this function calculates a
+	 *  second Location the LocationVector points to (only the azimuth is used;
+	 * backAzimuth is ignored). The fields calculated for the
+	 *  second Location are:
+	 *
+	 * <uL>
+	 * <li>Lat
+	 * <li>Lon
+	 * <li>Depth
+	 * </ul>
+	 *
+	 * @param  location1	First geographic location
+	 * @param  direction	LocationVector object pointing to second Location
+	 * @return location2	The second location
+	 * @exception  UnsupportedOperationException	Thrown if the Location or 
+	 * 				LocationVector contain bad data such as invalid latitudes
+	 * @see	 Location		to see the field definitions
+	 */
+	private static Location getLocationOLD(
+			Location location, LocationVector direction) 
+			throws UnsupportedOperationException {
+
+		double lat1 = location.lat();
+		double lon1 = location.lon();
+		double depth = location.depth();
+
+		double azimuth = direction.azimuth();
+		double horzDistance = direction.horizontal();
+		double vertDistance = direction.vertical();
+
+		double newLat = getLatitudeOLD( horzDistance, azimuth, lat1, lon1 );
+		double newLon= getLongitudeOLD( horzDistance, azimuth, lat1, lon1 );
+		// double newDepth = depth + -1*vertDistance;
+		double newDepth = depth + vertDistance;
+
+		Location newLoc = Location.create(newLat, newLon, newDepth);
+		return newLoc;
+	}
+
+	/**
+	 * OLD METHOD
+	 * 
+	 *  By passing in two Locations this calculator will determine the
+	 *  Distance object between them. The four fields calculated are:
+	 *
+	 * <uL>
+	 * <li>horzDistance
+	 * <li>azimuth
+	 * <li>backAzimuth
+	 * <li>vertDistance
+	 * </ul>
+	 *
+	 * @param  location1		First geographic location
+	 * @param  location2		Second geographic location
+	 * @return The direction, decomposition of the vector between two locations
+	 * @exception  UnsupportedOperationException
+	 * 		Thrown if the Locations contain bad data such as invalid latitudes
+	 * @see	 Distance			to see the field definitions
+	 */
+	private static LocationVector getDirectionOLD(
+			Location location1, Location location2) 
+			throws UnsupportedOperationException {
+
+		double lat1 = location1.lat();
+		double lon1 = location1.lon();
+		double lat2 = location2.lat();
+		double lon2 = location2.lon();
+
+		double horzDistance = getHorzDistanceOLD(location1, location2);
+		double azimuth = getAzimuthOLD(location1, location2);
+		double vertDistance = location2.depth() - location1.depth();
+
+		return LocationVector.create(azimuth, horzDistance, vertDistance);
+	}
+
+	/**
+	 * OLD METHOD
+	 * 
+	 * Internal helper method that calculates the latitude of a second location
+	 * given the input location and direction components
+	 *
+	 * @param delta			 Horizontal distance
+	 * @param azimuth		   angle towards new point
+	 * @param lat			   latitude of original point
+	 * @param lon			   longitude of original point
+	 * @return				  latitude of new point
+	 */
+	private static double getLatitudeOLD( 
+			double delta, double azimuth, double lat, double lon){
+
+		delta = ( delta / D_COEFF ) * RADIANS_CONVERSION;
+
+		double sdelt= Math.sin( delta );
+		double cdelt= Math.cos( delta );
+
+		double xlat = lat * RADIANS_CONVERSION;
+		//double xlon = lon * RADIANS_CONVERSION;
+
+		double az2 = azimuth * RADIANS_CONVERSION;
+
+		double st0 = Math.cos( xlat );
+		double ct0 = Math.sin( xlat );
+
+		//double phi0 = xlon;
+
+		double cz0 = Math.cos( az2 );
+		double ct1 = ( st0 * sdelt * cz0 ) + ( ct0 * cdelt );
+
+		double x = (st0 * cdelt ) - ( ct0 * sdelt * cz0 );
+		double y = sdelt * Math.sin( az2 );
+
+		double st1 =  Math.pow( ( ( x * x ) + ( y * y ) ), .5 );
+		//double dlon = Math.atan2( y, x );
+
+		double newLat = Math.atan2( ct1, st1 ) / RADIANS_CONVERSION;
+		return newLat;
+	}
+
+
+	/**
+	 * OLD METHOD
+	 * 
+	 * Internal helper method that calculates the longitude of a second location
+	 * given the input location and direction components
+	 *
+	 * @param delta			 Horizontal distance
+	 * @param azimuth		   angle towards new point
+	 * @param lat			   latitude of original point
+	 * @param lon			   longitude of original point
+	 * @return				  longitude of new point
+	 */
+	private static double getLongitudeOLD(
+			double delta, double azimuth, double lat, double lon){
+
+		delta = ( delta / D_COEFF ) * RADIANS_CONVERSION;
+
+		double sdelt= Math.sin( delta );
+		double cdelt= Math.cos( delta );
+
+		double xlat = lat * RADIANS_CONVERSION;
+		double xlon = lon * RADIANS_CONVERSION;
+
+		double az2 = azimuth * RADIANS_CONVERSION;
+
+		double st0 = Math.cos( xlat );
+		double ct0 = Math.sin( xlat );
+
+		double phi0 = xlon;
+
+		double cz0 = Math.cos( az2 );
+		// double ct1 = ( st0 * sdelt * cz0 ) + ( ct0 * cdelt );
+
+		double x = (st0 * cdelt ) - ( ct0 * sdelt * cz0 );
+		double y = sdelt * Math.sin( az2 );
+
+		//  double st1 =  Math.pow( ( ( x * x ) + ( y * y ) ), .5 );
+		double dlon = Math.atan2( y, x );
+
+		double newLon = ( phi0 + dlon ) / RADIANS_CONVERSION;
+		return newLon;
+	}
+
+	/**
+	 * 
+	 * OLD METHOD - although fast, curent implementation is faster and not
+	 * nearly as complicated
+	 * 
+	 * Computes the shortest distance between a point and a line. Both the 
+	 * line and point are assumed to be at the earth's surface; the depth
+	 * component of each <code>Location</code> is ignored. This is a fast,
+	 * geometric, cartesion (flat-earth approximation) solution in which
+	 * longitude is scaled by the cosine of latitude; it is only appropriate 
+	 * for use over short distances (e.g. &lt;200 km).<br/>
+	 * <br/>
+	 * <b>Note:</b> This method does <i>NOT</i> support values spanning 
+	 * &#177;180&#176; and results for such input values are not guaranteed.
+	 * 
+	 * @param p1 the first <code>Location</code> point on the line
+	 * @param p2 the second <code>Location</code> point on the line
+	 * @param p3 the <code>Location</code> point for which distance will 
+	 * 		be calculated
+	 * @return the shortest distance in km between the supplied point and line
+	 * @see #distanceToLine(Location, Location, Location)
+	 */
+	private static double distanceToLineFastOLD(
+			Location p1,
+			Location p2,
+			Location p3) {
+
+		double lat1 = p1.latRad();
+		double lat2 = p2.latRad();
+		double lat3 = p3.latRad();
+		double lon1 = p1.lonRad();
+		double lon2 = p2.lonRad();
+		double lon3 = p3.lonRad();
+
+		// use average latitude to scale longitude
+		double lonScale = Math.cos(0.5 * lat3 + 0.25 * lat1 + 0.25 * lat2);
+
+		// line-point corrdinates w/ loc transformed to the origin
+		double x1 = (lon1 - lon3) * lonScale;
+		double x2 = (lon2 - lon3) * lonScale;
+		double y1 = lat1 - lat3;
+		double y2 = lat2 - lat3;
+
+		double dist;
+
+		// check for values very close to zero
+		if (Math.abs(x1 - x2) > 1e-8) {
+			double m = (y2 - y1) / (x2 - x1); // slope
+			double b = y2 - m * x2; 		  // intercept
+			double xT = -m * b / (1 + m * m); // x target
+			double yT = m * xT + b; 		  // y target
+
+			// make sure the target point is in between the two endpoints
+			boolean betweenPts = false;
+			if (x2 > x1) {
+				if (xT <= x2 && xT >= x1) betweenPts = true;
+			} else {
+				if (xT <= x1 && xT >= x2) betweenPts = true;
+			}
+
+			if (betweenPts)
+				dist = Math.sqrt(xT * xT + yT * yT);
+			// return Math.sqrt(xT*xT + yT*yT) * EARTH_RADIUS_MEAN;
+			else {
+				double d1 = Math.sqrt(x1 * x1 + y1 * y1);
+				double d2 = Math.sqrt(x2 * x2 + y2 * y2);
+				dist = Math.min(d1, d2);
+			}
+		} else {
+			// the x1 = x2 case
+			if (y2 > y1) {
+				if (y2 <= 0.0) {
+					dist = Math.sqrt(x2 * x2 + y2 * y2);
+				} else if (y1 >= 0) {
+					dist = Math.sqrt(x1 * x1 + y1 * y1);
+				} else {
+					dist = Math.abs(x1);
+				}
+			} else {
+				// (y1 > y2)
+				if (y1 <= 0.0) {
+					dist = Math.sqrt(x1 * x1 + y1 * y1);
+				} else if (y2 >= 0) {
+					dist = Math.sqrt(x2 * x2 + y2 * y2);
+				} else {
+					dist = Math.abs(x1);
+				}
+			}
+		}
+		return dist * EARTH_RADIUS_MEAN;
+	}
+	
+	@Test
+	public void testCalcMinMaxLatLonEmpty() {
+		ArrayList<Location> locs = new ArrayList<Location>();
+		
+		assertTrue("calcMin* should return infinity when locs is empty",
+				Double.POSITIVE_INFINITY == Locations.calcMinLat(locs));
+		assertTrue("calcMin* should return infinity when locs is empty",
+				Double.POSITIVE_INFINITY == Locations.calcMinLon(locs));
+		
+		assertTrue("calcMax* should return -infinity when locs is empty",
+				Double.NEGATIVE_INFINITY == Locations.calcMaxLat(locs));
+		assertTrue("calcMax* should return -infinity when locs is empty",
+				Double.NEGATIVE_INFINITY == Locations.calcMaxLon(locs));
+	}
+
+	@Test
+	public void testCalcMinMaxLatLon() {
+		ArrayList<Location> locs = new ArrayList<Location>();
+		
+		locs.add(Location.create(34, -118));
+		locs.add(Location.create(35, -118));
+		locs.add(Location.create(35, -117));
+		locs.add(Location.create(34, -117));
+		
+		assertEquals("Min lat is wrong", 34f, (float)Locations.calcMinLat(locs), 0f);
+		assertEquals("Max lat is wrong", 35f, (float)Locations.calcMaxLat(locs), 0f);
+		
+		assertEquals("Min lon is wrong", -118f, (float)Locations.calcMinLon(locs), 0f);
+		assertEquals("Max lon is wrong", -117f, (float)Locations.calcMaxLon(locs), 0f);
+	}
+	
+	@Test (expected=NullPointerException.class)
+	public void testCalcMinLatNull() {
+		Locations.calcMinLat(null);
+	}
+	
+	@Test (expected=NullPointerException.class)
+	public void testCalcMinLonNull() {
+		Locations.calcMinLon(null);
+	}
+	
+	@Test (expected=NullPointerException.class)
+	public void testCalcMaxLatNull() {
+		Locations.calcMaxLat(null);
+	}
+	
+	@Test (expected=NullPointerException.class)
+	public void testCalcMaxLonNull() {
+		Locations.calcMaxLon(null);
+	}
+
+
+}


### PR DESCRIPTION
This branch began with work on the NSHMP rupture floating implementation. In order to tighten up the Location to Gridded Surface hierarchy, which is needed, extensive refactoring and test writing for geo/Location* classes was undertaken. Because the NSHMP floaters were actually implemented some time ago, we are now going to merge this branch and push further work on Locations and Grids to #85.

Although RuptureFloating still needs tests, it doesn't make sense to do so until a streamlined gridded surface hierarchy can be swapped in. There are no worthwhile tests fro the current hierarchy to be imported from OpenSHA and the method sprawl is unmanageable.

This closes #2.