### PR TITLE
Bounds addition to location based objects

### DIFF
--- a/src/org/opensha2/geo/GriddedRegion.java
+++ b/src/org/opensha2/geo/GriddedRegion.java
@@ -471,9 +471,10 @@ public class GriddedRegion extends Region implements Iterable<Location> {
 	 * Locations would coincide with grid nodes.
 	 */
 	private void setAnchor(Location anchor) {
-		if (anchor == null) anchor = Location.create(getMinLat(), getMinLon());
-		double lat = computeAnchor(getMinLat(), anchor.lat(), latSpacing);
-		double lon = computeAnchor(getMinLon(), anchor.lon(), lonSpacing);
+		Bounds bounds = bounds();
+		if (anchor == null) anchor = Location.create(bounds.min().lat(), bounds.min().lon());
+		double lat = computeAnchor(bounds.min().lat(), anchor.lat(), latSpacing);
+		double lon = computeAnchor(bounds.min().lon(), anchor.lon(), lonSpacing);
 		this.anchor = Location.create(lat, lon);
 	}
 
@@ -491,13 +492,15 @@ public class GriddedRegion extends Region implements Iterable<Location> {
 	/* Initilize the grid index, node edge, and Location arrays */
 	private void initNodes() {
 
+		Bounds bounds = bounds();
+		
 		// temp node center arrays
-		double[] lonNodes = initNodeCenters(anchor.lon(), getMaxLon(), lonSpacing);
-		double[] latNodes = initNodeCenters(anchor.lat(), getMaxLat(), latSpacing);
+		double[] lonNodes = initNodeCenters(anchor.lon(), bounds.max().lon(), lonSpacing);
+		double[] latNodes = initNodeCenters(anchor.lat(), bounds.max().lat(), latSpacing);
 
 		// node edge arrays
-		lonEdges = initNodeEdges(anchor.lon(), getMaxLon(), lonSpacing);
-		latEdges = initNodeEdges(anchor.lat(), getMaxLat(), latSpacing);
+		lonEdges = initNodeEdges(anchor.lon(), bounds.max().lon(), lonSpacing);
+		latEdges = initNodeEdges(anchor.lat(), bounds.max().lat(), latSpacing);
 
 		// range data
 		latSize = latNodes.length;

--- a/src/org/opensha2/geo/Region.java
+++ b/src/org/opensha2/geo/Region.java
@@ -283,35 +283,15 @@ public class Region implements Named {
 	}
 
 	/**
-	 * Returns the minimum latitude in this {@code Region}'s border.
-	 * @return the minimum latitude
+	 * Lazily create the bounds of this region.
 	 */
-	public double getMinLat() {
-		return area.getBounds2D().getMinY();
-	}
-
-	/**
-	 * Returns the maximum latitude in this {@code Region}'s border.
-	 * @return the maximum latitude
-	 */
-	public double getMaxLat() {
-		return area.getBounds2D().getMaxY();
-	}
-
-	/**
-	 * Returns the minimum longitude in this {@code Region}'s border.
-	 * @return the minimum longitude
-	 */
-	public double getMinLon() {
-		return area.getBounds2D().getMinX();
-	}
-
-	/**
-	 * Returns the maximum longitude in this {@code Region}'s border.
-	 * @return the maximum longitude
-	 */
-	public double getMaxLon() {
-		return area.getBounds2D().getMaxX();
+	public Bounds bounds() {
+		Rectangle2D bounds = area.getBounds2D();
+		return new Bounds(
+			bounds.getMinY(),
+			bounds.getMinX(),
+			bounds.getMaxY(),
+			bounds.getMaxX());
 	}
 
 	/**
@@ -343,9 +323,10 @@ public class Region implements Named {
 	}
 
 	@Override public String toString() {
-		String str = "Region\n" + "\tMinLat: " + this.getMinLat() + "\n" + "\tMinLon: " +
-			this.getMinLon() + "\n" + "\tMaxLat: " + this.getMaxLat() + "\n" + "\tMaxLon: " +
-			this.getMaxLon();
+		Bounds b = bounds();
+		String str = "Region\n" + "\tMinLat: " + b.min().lat() + "\n" + "\tMinLon: " +
+				b.min().lon() + "\n" + "\tMaxLat: " + b.max().lat() + "\n" + "\tMaxLon: " +
+				b.max().lon();
 		return str;
 	}
 


### PR DESCRIPTION
Along with prior commits, all Iterable<Location> classes have bounds methods and get[Min | Max][Lat | Lon]() methods have been removed.

LocationList
LocationGrid (beta)
Region

Resolves #89 