### PR TITLE
Fixed binary output

### DIFF
--- a/src/org/opensha2/calc/CurveType.java
+++ b/src/org/opensha2/calc/CurveType.java
@@ -29,7 +29,9 @@ public enum CurveType {
    * <p>The output format is a NSHMP file format that works with a number of
    * legacy fortran codes still in use. See <a
    * href="https://github.com/usgs/nshmp-haz-fortran"
-   * target="_top">nshmp-haz-fortran</a>.
+   * target="_top">nshmp-haz-fortran</a>. Users should be aware that the format
+   * has certain restrictions, for instance, the maximum number of intensity
+   * measure levels that can be accomodated is 20. Buyer beware.
    */
   BINARY;
 }

--- a/src/org/opensha2/eq/fault/surface/RuptureScaling.java
+++ b/src/org/opensha2/eq/fault/surface/RuptureScaling.java
@@ -249,8 +249,13 @@ public enum RuptureScaling {
 
   private static final String MAG_ID = "#Mag";
   private static final String COMMENT_ID = "#";
+  private static final double RJB_M_MIN = 6.05;
+  private static final double RJB_M_CUTOFF = 6.0;
+  private static final double RJB_M_DELTA = 0.1;
   private static final int RJB_M_SIZE = 26;
+  private static final int RJB_M_MAX_INDEX = RJB_M_SIZE - 1;
   private static final int RJB_R_SIZE = 1001;
+  private static final int RJB_R_MAX_INDEX = RJB_R_SIZE - 1;
   private static final double[][] RJB_DAT_WC94LENGTH = readRjb("etc/rjb_wc94length.dat");
   private static final double[][] RJB_DAT_GEOMATRIX = readRjb("etc/rjb_geomatrix.dat");
   private static final double[][] RJB_DAT_SOMERVILLE = readRjb("etc/rjb_somerville.dat");
@@ -295,14 +300,14 @@ public enum RuptureScaling {
    */
 
   private static double correctedRjb(double m, double r, double[][] rjb) {
-    if (m < 6.0) {
+    if (m < RJB_M_CUTOFF) {
       return r;
     }
-    int mIndex = min((int) round((m - 6.05) / 0.1), 25);
-    int rIndex = (int) floor(r);
-    return (rIndex <= 1000) ? rjb[mIndex][rIndex] : r;
+    int mIndex = min((int) round((m - RJB_M_MIN) / RJB_M_DELTA), RJB_M_MAX_INDEX);
+    int rIndex =  min(RJB_R_MAX_INDEX, (int) floor(r));
+    return rjb[mIndex][rIndex];
   }
-
+  
   /**
    * Return the dimensions of a magnitude-dependent and width-constrained
    * rupture.

--- a/src/org/opensha2/gmm/AtkinsonBoore_2006p.java
+++ b/src/org/opensha2/gmm/AtkinsonBoore_2006p.java
@@ -75,16 +75,4 @@ public final class AtkinsonBoore_2006p implements GroundMotionModel {
     return DefaultScalarGroundMotion.create(GmmUtils.ceusMeanClip(imt, μ), SIGMA);
   }
 
-  // TODO clean
-  public static void main(String[] args) {
-    AtkinsonBoore_2006p gmm = new AtkinsonBoore_2006p(Imt.PGA);
-    double m = atkinsonTableValue(gmm.table, Imt.PGA, 3.5, 4.0, 760.0, gmm.bcfac);
-    System.out.println(m);
-    System.out.println(Math.exp(m));
-    double clipped = GmmUtils.ceusMeanClip(Imt.PGA, m);
-    System.out.println(clipped);
-    System.out.println(Math.exp(clipped));
-
-  }
-
 }

--- a/src/org/opensha2/internal/NshmpSite.java
+++ b/src/org/opensha2/internal/NshmpSite.java
@@ -22,7 +22,7 @@ public enum NshmpSite implements NamedLocation {
 
   /*
    * Items are organized broadly by state and states are grouped as belonging
-   * either to northern or southern Caligornia, the intermountain west, the
+   * either to northern or southern California, the intermountain west, the
    * Pacific northwest, of the central and eastern US.
    */
 


### PR DESCRIPTION
Resolves #62 

Updated NSHM indexing algorithm and binary write OpenOptions. Restructured metadata to store one instance per IMT, and including a reference ByteBuffer appropriately sized to the number of IMLs (IMT-dependent).