### PR TITLE
Fix for config and log serialization on Windows

### DIFF
--- a/src/org/opensha2/DeaggCalc.java
+++ b/src/org/opensha2/DeaggCalc.java
@@ -102,12 +102,13 @@ public class DeaggCalc {
       double returnPeriod = Double.valueOf(args[2]);
 
       Path out = calc(model, config, sites, returnPeriod, log);
+      log.info(PROGRAM + ": finished");
 
-      // transfer log and write config
+      /* Transfer log and write config, windows requires fh.close() */
+      fh.close();
       Files.move(tempLog, out.resolve(PROGRAM + ".log"));
       config.write(out);
 
-      log.info(PROGRAM + ": finished");
       return Optional.absent();
 
     } catch (Exception e) {

--- a/src/org/opensha2/HazardCalc.java
+++ b/src/org/opensha2/HazardCalc.java
@@ -109,7 +109,7 @@ public class HazardCalc {
       Path out = calc(model, config, sites, log);
       log.info(PROGRAM + ": finished");
 
-      // transfer log and write config
+      /* Transfer log and write config, windows requires fh.close() */
       fh.close();
       Files.move(tempLog, out.resolve(PROGRAM + ".log"));
       config.write(out);

--- a/src/org/opensha2/HazardCalc.java
+++ b/src/org/opensha2/HazardCalc.java
@@ -107,12 +107,13 @@ public class HazardCalc {
       log.info("Sites: " + sites);
 
       Path out = calc(model, config, sites, log);
+      log.info(PROGRAM + ": finished");
 
       // transfer log and write config
+      fh.close();
       Files.move(tempLog, out.resolve(PROGRAM + ".log"));
       config.write(out);
 
-      log.info(PROGRAM + ": finished");
       return Optional.absent();
 
     } catch (Exception e) {

--- a/src/org/opensha2/calc/CalcConfig.java
+++ b/src/org/opensha2/calc/CalcConfig.java
@@ -955,12 +955,6 @@ public final class CalcConfig {
     writer.close();
   }
 
-  public static void main(String[] args) throws IOException {
-    CalcConfig c = Builder.withDefaults().build();
-    String s = GSON.toJson(c);
-    System.out.println(s);
-  }
-
   /**
    * A builder of configuration instances.
    */


### PR DESCRIPTION
Separated type adapters into static classes.
Registered Path (de)serializer as typeHeirarchyAdapter.
In both HazardCalc and DeaggCalc, closed FileHandler before moving log.

Resolves #193 