### PR TITLE
GeoJson and NshmpSite Update

### DIFF
--- a/src/gov/usgs/earthquake/nshmp/internal/GeoJson.java
+++ b/src/gov/usgs/earthquake/nshmp/internal/GeoJson.java
@@ -181,6 +181,14 @@ public final class GeoJson {
     @SerializedName("marker-color")
     String strokeColor;
   }
+  
+  public static Feature regionBounds(double lon,double lat) {
+    double[] coordinates = {lon,lat};
+    Feature f = new Feature();
+    f.geometry.type = "Point";
+    f.geometry.coordinates = coordinates;
+    return f;
+  }
 
   static double[] toCoordinates(Location loc) {
     return new double[] { round(loc.lon(), 5), round(loc.lat(), 5) };

--- a/src/gov/usgs/earthquake/nshmp/internal/GeoJson.java
+++ b/src/gov/usgs/earthquake/nshmp/internal/GeoJson.java
@@ -109,14 +109,6 @@ public final class GeoJson {
     Geometry geometry = new Geometry();
     PropertiesObject properties;
   }
-
-  public static Feature regionBounds(double lon, double lat) {
-    Feature f = new Feature();
-    double[] coordinates = {lon,lat};
-    f.geometry.type = "Point";
-    f.geometry.coordinates = coordinates;
-    return f;
-  }
   
   public static Feature createPoint(NamedLocation loc) {
     Feature f = new Feature();

--- a/src/gov/usgs/earthquake/nshmp/internal/NshmpSite.java
+++ b/src/gov/usgs/earthquake/nshmp/internal/NshmpSite.java
@@ -312,7 +312,8 @@ public enum NshmpSite implements NamedLocation {
           }
         }), NshmpSite.class);
   }
-
+  
+  
   /**
    * The set of sites used to test the Western US NSHM. This includes all NSHMP
    * sites west of -100.0°.
@@ -328,6 +329,21 @@ public enum NshmpSite implements NamedLocation {
         }), NshmpSite.class);
   }
 
+  
+  /**
+   * The combination of CEUS and WUS
+   */
+  public static EnumSet<NshmpSite> cous() {
+    return Sets.newEnumSet(Iterables.filter(
+        EnumSet.allOf(NshmpSite.class),
+        new Predicate<NshmpSite>() {
+          @Override
+          public boolean apply(NshmpSite site) {
+            return site.location.lon() <=-100.0 || site.location.lon() >= -115.0;
+          }
+        }), NshmpSite.class);
+  }
+  
   /**
    * The set of sites used to test the Alaska NSHM.
    */


### PR DESCRIPTION
Updated the GeoJson and NshmpSite Java files.

### GeoJson
Location: /src/gov/usgs/earthquake/nshmp/internal
#### New Method: regionBounds
* This method is for creating a GeoJson features for the min and max values of a region for the location widget.
* This method takes two arguments: (double longitude, double latitude)
* This method returns a GeoJson feature.

### NshmpSite
Location: src/gov/usgs/earthquake/nshmp/internal
#### New Method: cous
* This method is for creating an EnumSet of NshmpSite for the conterminous US. It is a combination of the wus and ceus method.
