### PR TITLE
External grid ratefile update

### DIFF
--- a/src/gov/usgs/earthquake/nshmp/HazardCalc.java
+++ b/src/gov/usgs/earthquake/nshmp/HazardCalc.java
@@ -207,10 +207,11 @@ public class HazardCalc {
       String program,
       String usage) {
     
-    log.log(SEVERE, "** Exiting **" + NEWLINE, e);
+    log.severe(NEWLINE + "** Exiting **");
     try {
+      // cleanup; do nothing on failure
       Files.deleteIfExists(logfile);
-    } catch (IOException ioe) {} // do nothing
+    } catch (IOException ioe) {} 
     StringBuilder sb = new StringBuilder()
         .append(NEWLINE)
         .append(program + ": error").append(NEWLINE)

--- a/src/gov/usgs/earthquake/nshmp/calc/Sites.java
+++ b/src/gov/usgs/earthquake/nshmp/calc/Sites.java
@@ -64,7 +64,7 @@ public abstract class Sites implements Iterable<Site> {
 
   private static Sites readCsv(Path path, CalcConfig defaults) throws IOException {
 
-    checkArgument(Files.exists(path), "Specified site file [%s] does not exist", path);
+    checkArgument(Files.exists(path), "Site file [%s] does not exist", path);
 
     ImmutableList.Builder<Site> listBuilder = ImmutableList.builder();
     Builder siteBuilder = Site.builder(defaults);
@@ -142,7 +142,7 @@ public abstract class Sites implements Iterable<Site> {
    * @throws IOException if a problem is encountered
    */
   public static Sites fromJson(Path path, CalcConfig defaults) throws IOException {
-    checkArgument(Files.exists(path), "Specified site file [%s] does not exist", path);
+    checkArgument(Files.exists(path), "Site file [%s] does not exist", path);
     Gson gson = new GsonBuilder()
         .registerTypeAdapter(Site.class, new Site.Deserializer(defaults))
         .registerTypeAdapter(Sites.class, new Deserializer(defaults))

--- a/src/gov/usgs/earthquake/nshmp/eq/model/AreaParser.java
+++ b/src/gov/usgs/earthquake/nshmp/eq/model/AreaParser.java
@@ -86,8 +86,11 @@ class AreaParser extends DefaultHandler {
     return new AreaParser(sax);
   }
 
-  AreaSourceSet parse(InputStream in, GmmSet gmmSet, ModelConfig config) throws SAXException,
-      IOException {
+  AreaSourceSet parse(
+      InputStream in,
+      GmmSet gmmSet,
+      ModelConfig config) throws SAXException, IOException {
+
     checkState(!used, "This parser has expired");
     this.gmmSet = gmmSet;
     this.config = config;
@@ -97,8 +100,10 @@ class AreaParser extends DefaultHandler {
   }
 
   @Override
-  public void startElement(String uri, String localName, String qName, Attributes atts)
-      throws SAXException {
+  public void startElement(
+      String uri,
+      String localName,
+      String qName, Attributes atts) throws SAXException {
 
     SourceElement e = null;
     try {
@@ -196,8 +201,10 @@ class AreaParser extends DefaultHandler {
   }
 
   @Override
-  public void endElement(String uri, String localName, String qName)
-      throws SAXException {
+  public void endElement(
+      String uri,
+      String localName,
+      String qName) throws SAXException {
 
     SourceElement e = null;
     try {

--- a/src/gov/usgs/earthquake/nshmp/eq/model/ClusterParser.java
+++ b/src/gov/usgs/earthquake/nshmp/eq/model/ClusterParser.java
@@ -92,8 +92,11 @@ class ClusterParser extends DefaultHandler {
     return new ClusterParser(checkNotNull(sax));
   }
 
-  ClusterSourceSet parse(InputStream in, GmmSet gmmSet, ModelConfig config) throws SAXException,
-      IOException {
+  ClusterSourceSet parse(
+      InputStream in,
+      GmmSet gmmSet,
+      ModelConfig config) throws SAXException, IOException {
+
     checkState(!used, "This parser has expired");
     this.gmmSet = gmmSet;
     this.config = config;
@@ -104,8 +107,11 @@ class ClusterParser extends DefaultHandler {
   }
 
   @Override
-  public void startElement(String uri, String localName, String qName, Attributes atts)
-      throws SAXException {
+  public void startElement(
+      String uri,
+      String localName,
+      String qName,
+      Attributes atts) throws SAXException {
 
     SourceElement e = null;
     try {
@@ -215,8 +221,10 @@ class ClusterParser extends DefaultHandler {
   }
 
   @Override
-  public void endElement(String uri, String localName, String qName)
-      throws SAXException {
+  public void endElement(
+      String uri,
+      String localName,
+      String qName) throws SAXException {
 
     SourceElement e = null;
     try {

--- a/src/gov/usgs/earthquake/nshmp/eq/model/FaultParser.java
+++ b/src/gov/usgs/earthquake/nshmp/eq/model/FaultParser.java
@@ -95,8 +95,11 @@ class FaultParser extends DefaultHandler {
     return new FaultParser(checkNotNull(sax));
   }
 
-  FaultSourceSet parse(InputStream in, GmmSet gmmSet, ModelConfig config) throws SAXException,
-      IOException {
+  FaultSourceSet parse(
+      InputStream in,
+      GmmSet gmmSet,
+      ModelConfig config) throws SAXException, IOException {
+
     checkState(!used, "This parser has expired");
     this.gmmSet = gmmSet;
     this.config = config;
@@ -107,8 +110,11 @@ class FaultParser extends DefaultHandler {
   }
 
   @Override
-  public void startElement(String uri, String localName, String qName, Attributes atts)
-      throws SAXException {
+  public void startElement(
+      String uri,
+      String localName,
+      String qName,
+      Attributes atts) throws SAXException {
 
     SourceElement e = null;
     try {
@@ -200,8 +206,10 @@ class FaultParser extends DefaultHandler {
   }
 
   @Override
-  public void endElement(String uri, String localName, String qName)
-      throws SAXException {
+  public void endElement(
+      String uri,
+      String localName,
+      String qName) throws SAXException {
 
     SourceElement e = null;
     try {
@@ -412,8 +420,7 @@ class FaultParser extends DefaultHandler {
         } else {
 
           // single Mfds with epi uncertainty are moment balanced at
-          // the
-          // central/single magnitude of the distribution
+          // the central/single magnitude of the distribution
 
           double moRate = tmr * mfdWeight;
           IncrementalMfd mfd = Mfds.newSingleMoBalancedMFD(epiMag, moRate, data.floats);

--- a/src/gov/usgs/earthquake/nshmp/eq/model/GmmParser.java
+++ b/src/gov/usgs/earthquake/nshmp/eq/model/GmmParser.java
@@ -72,8 +72,11 @@ class GmmParser extends DefaultHandler {
   }
 
   @Override
-  public void startElement(String uri, String localName, String qName, Attributes atts)
-      throws SAXException {
+  public void startElement(
+      String uri,
+      String localName,
+      String qName,
+      Attributes atts) throws SAXException {
 
     GmmElement e = null;
     try {
@@ -134,8 +137,10 @@ class GmmParser extends DefaultHandler {
   }
 
   @Override
-  public void endElement(String uri, String localName, String qName)
-      throws SAXException {
+  public void endElement(
+      String uri,
+      String localName,
+      String qName) throws SAXException {
 
     GmmElement e = null;
     try {

--- a/src/gov/usgs/earthquake/nshmp/eq/model/HazardModel.java
+++ b/src/gov/usgs/earthquake/nshmp/eq/model/HazardModel.java
@@ -5,12 +5,15 @@ import static com.google.common.base.Preconditions.checkState;
 import static gov.usgs.earthquake.nshmp.internal.TextUtils.NEWLINE;
 import static gov.usgs.earthquake.nshmp.internal.TextUtils.validateName;
 
+import org.xml.sax.SAXException;
+
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Set;
@@ -77,14 +80,15 @@ public final class HazardModel implements Iterable<SourceSet<? extends Source>>,
    * href="https://github.com/usgs/nshmp-haz/wiki/Earthquake-Source-Models"
    * target="_top">nshmp-haz wiki</a>.
    *
-   * <p><b>Notes:</b> HazardModel loading is not thread safe. Also, there are a
-   * wide variety of exceptions that may be encountered when loading a model. In
-   * most cases, the exception will be logged and the JVM will exit.
+   * <p><b>Notes:</b> HazardModel loading is not thread safe. There are also a
+   * wide variety of exceptions that may be encountered when loading a model.
+   * Exceptions are generally logged and propagated back to calling application
+   * to handle termination.
    *
    * @param path to {@code HazardModel} directory or Zip file
    * @return a newly instantiated {@code HazardModel}
    */
-  public static HazardModel load(Path path) {
+  public static HazardModel load(Path path) throws SAXException, IOException {
     return Loader.load(path);
   }
 

--- a/src/gov/usgs/earthquake/nshmp/eq/model/InterfaceParser.java
+++ b/src/gov/usgs/earthquake/nshmp/eq/model/InterfaceParser.java
@@ -82,8 +82,11 @@ class InterfaceParser extends DefaultHandler {
     return new InterfaceParser(checkNotNull(sax));
   }
 
-  InterfaceSourceSet parse(InputStream in, GmmSet gmmSet, ModelConfig config) throws SAXException,
-      IOException {
+  InterfaceSourceSet parse(
+      InputStream in, 
+      GmmSet gmmSet, 
+      ModelConfig config) throws SAXException, IOException {
+    
     checkState(!used, "This parser has expired");
     this.gmmSet = gmmSet;
     this.config = config;
@@ -94,8 +97,11 @@ class InterfaceParser extends DefaultHandler {
   }
 
   @Override
-  public void startElement(String uri, String localName, String qName, Attributes atts)
-      throws SAXException {
+  public void startElement(
+      String uri, 
+      String localName, 
+      String qName, 
+      Attributes atts) throws SAXException {
 
     SourceElement e = null;
     try {
@@ -194,8 +200,10 @@ class InterfaceParser extends DefaultHandler {
   }
 
   @Override
-  public void endElement(String uri, String localName, String qName)
-      throws SAXException {
+  public void endElement(
+      String uri, 
+      String localName, 
+      String qName) throws SAXException {
 
     SourceElement e = null;
     try {

--- a/src/gov/usgs/earthquake/nshmp/eq/model/Loader.java
+++ b/src/gov/usgs/earthquake/nshmp/eq/model/Loader.java
@@ -2,10 +2,10 @@ package gov.usgs.earthquake.nshmp.eq.model;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.StandardSystemProperty.LINE_SEPARATOR;
 import static gov.usgs.earthquake.nshmp.eq.model.SystemParser.GRIDSOURCE_FILENAME;
 import static gov.usgs.earthquake.nshmp.eq.model.SystemParser.RUPTURES_FILENAME;
 import static gov.usgs.earthquake.nshmp.eq.model.SystemParser.SECTIONS_FILENAME;
+import static gov.usgs.earthquake.nshmp.internal.TextUtils.NEWLINE;
 import static java.nio.file.Files.newDirectoryStream;
 import static java.util.logging.Level.SEVERE;
 
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -41,17 +42,15 @@ import gov.usgs.earthquake.nshmp.calc.CalcConfig;
 import gov.usgs.earthquake.nshmp.eq.model.HazardModel.Builder;
 
 /**
- * {@code HazardModel} loader. This class takes care of extensive checked
- * exceptions required when initializing a {@code HazardModel} and will exit the
- * JVM in most cases.
+ * {@code HazardModel} loader. This class logs information relevant to the many
+ * various exceptions, both checked and unchecked, that may be thrown when
+ * initializing a {@code HazardModel}.
  *
  * @author Peter Powers
  */
 class Loader {
 
   static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
-
-  private static final String LF = LINE_SEPARATOR.value();
   private static Logger log;
 
   static {
@@ -63,27 +62,25 @@ class Loader {
    * directory containing sub-directories by {@code SourceType}s, or the
    * absolute path to a zipped model.
    *
-   * <p>This method is not thread safe. Any exceptions thrown while loading will
-   * be logged and the JVM will exit.
+   * <p>This method is not thread safe. This method wraps all {@code Runtime}
+   * and other exceptions in {@code IO} and {@code SAXException}s.
    *
    * @param path to model directory or Zip file (absolute)
    * @return a newly created {@code HazardModel}
    */
-  static HazardModel load(Path path) {
-
-    SAXParser sax = null;
-    try {
-      sax = SAXParserFactory.newInstance().newSAXParser();
-    } catch (ParserConfigurationException | SAXException e) {
-      throw new RuntimeException(e);
-    }
-
-    HazardModel.Builder builder = HazardModel.builder();
-    List<Path> typePaths = null;
+  static HazardModel load(Path path) throws IOException, SAXException {
 
     try {
 
-      checkArgument(Files.exists(path), "Specified model does not exist: %s", path);
+      SAXParser sax = SAXParserFactory.newInstance().newSAXParser();
+
+      if (!Files.exists(path)) {
+        String mssg = String.format("Specified model does not exist: %s", path);
+        throw new FileNotFoundException(mssg);
+      }
+
+      HazardModel.Builder builder = HazardModel.builder();
+      List<Path> typePaths = null;
       Path typeDirPath = typeDirectory(path);
 
       ModelConfig modelConfig = ModelConfig.Builder.fromFile(typeDirPath).build();
@@ -106,18 +103,24 @@ class Loader {
         log.info("==========================" + Strings.repeat("=", typeName.length()));
       }
 
-    } catch (IOException | URISyntaxException e) {
-      handleConfigException(e);
+      log.info("");
+      HazardModel model = builder.build();
+      return model;
+
+    } catch (URISyntaxException | ParserConfigurationException oe) {
+      log.severe(NEWLINE + "** Error loading model **");
+      throw new IOException(oe);
+    } catch (Exception e) {
+      log.severe(NEWLINE + "** Error loading model **");
+      throw e;
     }
-
-    log.info("");
-    HazardModel model = builder.build();
-
-    return model;
   }
 
-  private static final Map<String, String> ZIP_ENV_MAP = ImmutableMap.of("create", "false",
-      "encoding", "UTF-8");
+  private static final Map<String, String> ZIP_ENV_MAP = ImmutableMap.of(
+      "create",
+      "false",
+      "encoding",
+      "UTF-8");
 
   private static final String ZIP_SCHEME = "jar:file";
 
@@ -170,7 +173,7 @@ class Loader {
       Path typeDir,
       Builder builder,
       ModelConfig modelConfig,
-      SAXParser sax) throws IOException {
+      SAXParser sax) throws IOException, SAXException {
 
     String typeName = cleanZipName(typeDir.getFileName().toString());
     SourceType type = SourceType.fromString(typeName);
@@ -202,14 +205,9 @@ class Loader {
     Path gmmPath = typeDir.resolve(GmmParser.FILE_NAME);
 
     // if source files exist, gmm.xml must also exist
-    if (typePaths.size() > 0) {
-      try {
-        checkState(Files.exists(gmmPath), "%s sources present. Where is gmm.xml?",
-            typeDir.getFileName());
-      } catch (IllegalStateException ise) {
-        handleConfigException(ise);
-        throw ise;
-      }
+    if (typePaths.size() > 0 && !Files.exists(gmmPath)) {
+      String mssg = gmmErrorMessage(typeDir.getFileName());
+      throw new FileNotFoundException(mssg);
     }
 
     // having checked directory state, load gmms if present
@@ -221,8 +219,7 @@ class Loader {
 
     for (Path sourcePath : typePaths) {
       log.info("Parsing: " + typeDir.getParent().relativize(sourcePath));
-      SourceSet<? extends Source> sourceSet = parseSource(type, sourcePath, gmmSet, config,
-          sax);
+      SourceSet<? extends Source> sourceSet = parseSource(type, sourcePath, gmmSet, config, sax);
       builder.sourceSet(sourceSet);
     }
 
@@ -246,7 +243,7 @@ class Loader {
       GmmSet gmmSet,
       Builder builder,
       ModelConfig parentConfig,
-      SAXParser sax) throws IOException {
+      SAXParser sax) throws IOException, SAXException {
 
     /*
      * gmm.xml -- this MUST exist if there is at least one source file and there
@@ -255,8 +252,7 @@ class Loader {
 
     // Collect nested paths
     List<Path> nestedSourcePaths = null;
-    try (DirectoryStream<Path> ds =
-        Files.newDirectoryStream(sourceDir, SourceFilter.INSTANCE)) {
+    try (DirectoryStream<Path> ds = Files.newDirectoryStream(sourceDir, SourceFilter.INSTANCE)) {
       nestedSourcePaths = Lists.newArrayList(ds);
     }
 
@@ -277,12 +273,9 @@ class Loader {
 
       // gmm
       Path nestedGmmPath = sourceDir.resolve(GmmParser.FILE_NAME);
-      try {
-        checkState(Files.exists(nestedGmmPath) || gmmSet != null,
-            "%s sources present. Where is gmm.xml?", sourceDir.getFileName());
-      } catch (IllegalStateException ise) {
-        handleConfigException(ise);
-        throw ise;
+      if (!Files.exists(nestedGmmPath) && gmmSet != null) {
+        String mssg = gmmErrorMessage(sourceDir.getFileName());
+        throw new FileNotFoundException(mssg);
       }
 
       if (Files.exists(nestedGmmPath)) {
@@ -313,7 +306,7 @@ class Loader {
       Path path,
       GmmSet gmmSet,
       ModelConfig config,
-      SAXParser sax) {
+      SAXParser sax) throws IOException, SAXException {
 
     try (InputStream in = Files.newInputStream(path)) {
       switch (type) {
@@ -346,7 +339,7 @@ class Loader {
       GmmSet gmmSet,
       Builder builder,
       ModelConfig config,
-      SAXParser sax) {
+      SAXParser sax) throws IOException, SAXException {
 
     log.info("");
     try {
@@ -379,7 +372,8 @@ class Loader {
     }
   }
 
-  private static GmmSet parseGMM(Path path, SAXParser sax) {
+  private static GmmSet parseGMM(Path path, SAXParser sax)
+      throws IOException, SAXException {
     try {
       InputStream in = Files.newInputStream(path);
       return GmmParser.create(sax).parse(in);
@@ -389,45 +383,45 @@ class Loader {
     }
   }
 
-  /* This method will exit runtime environment */
-  private static void handleConfigException(Exception e) {
-    StringBuilder sb = new StringBuilder(LF);
-    sb.append("** Configuration error: ").append(e.getMessage());
-    log.log(SEVERE, sb.toString(), e);
-    System.exit(1);
-  }
+  /* Called from all *parse*() methods. */
+  private static void handleParseException(Exception e, Path path)
+      throws IOException, SAXException {
 
-  /* This method will exit runtime environment */
-  private static void handleParseException(Exception e, Path path) {
-    StringBuilder sb = new StringBuilder(LF);
+    StringBuilder sb = new StringBuilder(NEWLINE);
+    sb.append("** Parsing error: ");
     if (e instanceof SAXParseException) {
       SAXParseException spe = (SAXParseException) e;
-      sb.append("** SAX parser error:").append(LF);
-      sb.append("**   Path: ").append(path).append(LF);
+      sb.append("SAX parser **").append(NEWLINE);
+      sb.append("**   Path: ").append(path).append(NEWLINE);
       sb.append("**   Line: ").append(spe.getLineNumber());
-      sb.append(" [").append(spe.getColumnNumber()).append("]").append(LF);
-      sb.append("**   Info: ").append(spe.getMessage()).append(LF);
+      sb.append(" [").append(spe.getColumnNumber()).append("]").append(NEWLINE);
+      sb.append("**   Info: ").append(spe.getMessage());
+      log.severe(sb.toString());
+      throw spe;
     } else if (e instanceof SAXException) {
-      sb.append("** Other SAX parsing error **");
+      sb.append("Other SAX error **");
+      log.severe(sb.toString());
+      throw (SAXException) e;
     } else if (e instanceof IOException) {
       IOException ioe = (IOException) e;
-      sb.append("** IO error: ").append(ioe.getMessage()).append(LF);
-      sb.append("**     Path: ").append(path).append(LF);
-    } else if (e instanceof UnsupportedOperationException ||
-        e instanceof IllegalStateException ||
-        e instanceof NullPointerException) {
-      sb.append("** Parsing error: ").append(e.getMessage()).append(LF);
+      sb.append("IO error ** ").append(NEWLINE);
+      sb.append("**     Path: ").append(path);
+      log.severe(sb.toString());
+      throw ioe;
     } else {
-      sb.append("** Unknown parsing error: ").append(e.getMessage()).append(LF);
+      sb.append("Other error **");
+      log.severe(sb.toString());
+      throw new SAXException(e);
     }
-    sb.append("** Exiting **").append(LF).append(LF);
-    log.log(SEVERE, sb.toString(), e);
-    System.exit(1);
   }
 
   /* Prune trailing slash if such exists. */
   private static String cleanZipName(String name) {
     return name.endsWith("/") ? name.substring(0, name.length() - 1) : name;
+  }
+
+  private static String gmmErrorMessage(Path dir) {
+    return dir + " sources present. Where is gmm.xml?";
   }
 
   /*

--- a/src/gov/usgs/earthquake/nshmp/eq/model/Loader.java
+++ b/src/gov/usgs/earthquake/nshmp/eq/model/Loader.java
@@ -166,7 +166,10 @@ class Loader {
     }
   }
 
-  private static void processTypeDir(Path typeDir, Builder builder, ModelConfig modelConfig,
+  private static void processTypeDir(
+      Path typeDir,
+      Builder builder,
+      ModelConfig modelConfig,
       SAXParser sax) throws IOException {
 
     String typeName = cleanZipName(typeDir.getFileName().toString());
@@ -237,8 +240,13 @@ class Loader {
     }
   }
 
-  private static void processNestedDir(Path sourceDir, SourceType type, GmmSet gmmSet,
-      Builder builder, ModelConfig parentConfig, SAXParser sax) throws IOException {
+  private static void processNestedDir(
+      Path sourceDir,
+      SourceType type,
+      GmmSet gmmSet,
+      Builder builder,
+      ModelConfig parentConfig,
+      SAXParser sax) throws IOException {
 
     /*
      * gmm.xml -- this MUST exist if there is at least one source file and there
@@ -300,10 +308,14 @@ class Loader {
     }
   }
 
-  private static SourceSet<? extends Source> parseSource(SourceType type, Path path,
-      GmmSet gmmSet, ModelConfig config, SAXParser sax) {
-    try {
-      InputStream in = Files.newInputStream(path);
+  private static SourceSet<? extends Source> parseSource(
+      SourceType type,
+      Path path,
+      GmmSet gmmSet,
+      ModelConfig config,
+      SAXParser sax) {
+
+    try (InputStream in = Files.newInputStream(path)) {
       switch (type) {
         case AREA:
           return AreaParser.create(sax).parse(in, gmmSet, config);
@@ -329,8 +341,13 @@ class Loader {
     }
   }
 
-  private static void parseSystemSource(Path dir, GmmSet gmmSet, Builder builder,
-      ModelConfig config, SAXParser sax) {
+  private static void parseSystemSource(
+      Path dir,
+      GmmSet gmmSet,
+      Builder builder,
+      ModelConfig config,
+      SAXParser sax) {
+
     log.info("");
     try {
       Path sectionsPath = dir.resolve(SECTIONS_FILENAME);
@@ -457,15 +474,17 @@ class Loader {
   }
 
   /*
-   * Filters nested source directories, skipping hidden directories and those
-   * that start with a tilde (~).
+   * Filters nested source directories, skipping hidden directories, those that
+   * start with a tilde (~), or that are named 'sources' that may exist in grid,
+   * area, or slab type directories.
    */
   private static enum NestedDirFilter implements DirectoryStream.Filter<Path> {
     INSTANCE;
     @Override
     public boolean accept(Path path) throws IOException {
       String s = path.getFileName().toString();
-      return Files.isDirectory(path) && !Files.isHidden(path) && !s.startsWith("~");
+      return Files.isDirectory(path) && !Files.isHidden(path) && !s.startsWith("~") &&
+          !s.equals(GridParser.RATE_DIR);
     }
   }
 

--- a/src/gov/usgs/earthquake/nshmp/eq/model/ModelConfig.java
+++ b/src/gov/usgs/earthquake/nshmp/eq/model/ModelConfig.java
@@ -37,7 +37,7 @@ final class ModelConfig {
 
   private static final Gson GSON = new GsonBuilder().create();
 
-  private final Path resource;
+  final Path resource;
 
   final String name;
   final double surfaceSpacing;

--- a/src/gov/usgs/earthquake/nshmp/eq/model/SlabParser.java
+++ b/src/gov/usgs/earthquake/nshmp/eq/model/SlabParser.java
@@ -27,8 +27,11 @@ class SlabParser {
     return new SlabParser(sax);
   }
 
-  SlabSourceSet parse(InputStream in, GmmSet gmmSet, ModelConfig config) throws SAXException,
-      IOException {
+  SlabSourceSet parse(
+      InputStream in,
+      GmmSet gmmSet,
+      ModelConfig config) throws SAXException, IOException {
+
     GridSourceSet delegate = gridParser.parse(in, gmmSet, config);
     return new SlabSourceSet(delegate);
   }

--- a/src/gov/usgs/earthquake/nshmp/eq/model/SystemParser.java
+++ b/src/gov/usgs/earthquake/nshmp/eq/model/SystemParser.java
@@ -98,8 +98,11 @@ class SystemParser extends DefaultHandler {
     return new SystemParser(checkNotNull(sax));
   }
 
-  SystemSourceSet parse(InputStream sectionsIn, InputStream rupturesIn, GmmSet gmmSet)
-      throws SAXException, IOException {
+  SystemSourceSet parse(
+      InputStream sectionsIn,
+      InputStream rupturesIn,
+      GmmSet gmmSet) throws SAXException, IOException {
+
     checkState(!used, "This parser has expired");
     this.gmmSet = gmmSet;
     parseSections(sectionsIn);
@@ -117,8 +120,11 @@ class SystemParser extends DefaultHandler {
   }
 
   @Override
-  public void startElement(String uri, String localName, String qName, Attributes atts)
-      throws SAXException {
+  public void startElement(
+      String uri,
+      String localName,
+      String qName,
+      Attributes atts) throws SAXException {
 
     SourceElement e = null;
     try {
@@ -181,8 +187,10 @@ class SystemParser extends DefaultHandler {
   }
 
   @Override
-  public void endElement(String uri, String localName, String qName)
-      throws SAXException {
+  public void endElement(
+      String uri,
+      String localName,
+      String qName) throws SAXException {
 
     SourceElement e = null;
     try {

--- a/src/gov/usgs/earthquake/nshmp/eq/model/SystemSectionParser.java
+++ b/src/gov/usgs/earthquake/nshmp/eq/model/SystemSectionParser.java
@@ -88,8 +88,11 @@ class SystemSectionParser extends DefaultHandler {
   }
 
   @Override
-  public void startElement(String uri, String localName, String qName, Attributes atts)
-      throws SAXException {
+  public void startElement(
+      String uri,
+      String localName,
+      String qName,
+      Attributes atts) throws SAXException {
 
     SourceElement e = null;
     try {
@@ -144,8 +147,10 @@ class SystemSectionParser extends DefaultHandler {
   }
 
   @Override
-  public void endElement(String uri, String localName, String qName)
-      throws SAXException {
+  public void endElement(
+      String uri,
+      String localName,
+      String qName) throws SAXException {
 
     SourceElement e = null;
     try {

--- a/src/gov/usgs/earthquake/nshmp/internal/Logging.java
+++ b/src/gov/usgs/earthquake/nshmp/internal/Logging.java
@@ -30,7 +30,7 @@ public class Logging {
       InputStream is = Logging.class.getResourceAsStream("/logging.properties");
       LogManager.getLogManager().readConfiguration(is);
     } catch (IOException ioe) {
-      ioe.printStackTrace();
+      throw new RuntimeException(ioe);
     }
   }
 
@@ -44,9 +44,8 @@ public class Logging {
     Logger log = Logger.getLogger(clazz.getName());
     StringBuilder sb = new StringBuilder(LF);
     sb.append("** Error loading resource: ").append(e.getMessage()).append(LF);
-    sb.append("** Exiting **").append(LF).append(LF);
     log.log(SEVERE, sb.toString(), e);
-    System.exit(1);
+    throw new RuntimeException(e);
   }
 
   /**

--- a/src/gov/usgs/earthquake/nshmp/internal/NshmpSiteFiles.java
+++ b/src/gov/usgs/earthquake/nshmp/internal/NshmpSiteFiles.java
@@ -185,7 +185,7 @@ final class NshmpSiteFiles {
           Optional.<String> absent(),
           Optional.of(0.1)));
     }
-    FeatureCollection fc = new FeatureCollection();
+    FeatureCollection<Feature> fc = new FeatureCollection<Feature>();
     fc.features = features;
     String json = GeoJson.cleanPoly(GSON.toJson(fc));
     Files.write(out, json.getBytes(StandardCharsets.UTF_8));
@@ -211,7 +211,7 @@ final class NshmpSiteFiles {
         coords,
         Optional.<String> absent(),
         Optional.of(spacing)));
-    FeatureCollection fc = new FeatureCollection();
+    FeatureCollection<Feature> fc = new FeatureCollection<>();
     fc.features = features;
     String json = GeoJson.cleanPoly(GSON.toJson(fc));
     Files.write(out, json.getBytes(StandardCharsets.UTF_8));
@@ -365,7 +365,7 @@ final class NshmpSiteFiles {
     for (NamedLocation loc : sites) {
       features.add(GeoJson.createPoint(loc));
     }
-    FeatureCollection fc = new FeatureCollection();
+    FeatureCollection<Feature> fc = new FeatureCollection<>();
     fc.features = features;
     String json = GeoJson.cleanPoints(GSON.toJson(fc));
     Files.write(out, json.getBytes(StandardCharsets.UTF_8));
@@ -390,7 +390,7 @@ final class NshmpSiteFiles {
       feature.properties = props;
       features.add(feature);
     }
-    FeatureCollection fc = new FeatureCollection();
+    FeatureCollection<Feature> fc = new FeatureCollection<>();
     fc.features = features;
     String json = GeoJson.cleanPoints(GSON.toJson(fc));
     Files.write(out, json.getBytes(StandardCharsets.UTF_8));

--- a/src/gov/usgs/earthquake/nshmp/internal/SourceAttribute.java
+++ b/src/gov/usgs/earthquake/nshmp/internal/SourceAttribute.java
@@ -15,6 +15,7 @@ public enum SourceAttribute {
   ID,
   WEIGHT,
   INDEX,
+  PATH,
 
   /* Geometry specific */
   STRIKE,

--- a/src/gov/usgs/earthquake/nshmp/mfd/MfdType.java
+++ b/src/gov/usgs/earthquake/nshmp/mfd/MfdType.java
@@ -17,6 +17,11 @@ public enum MfdType {
   /** A Gutenberg-Richter MFD with a tapered upper tail. */
   GR_TAPER,
 
-  /** An MFD defining multiple magnitudes with varyig rates. */
+  /**
+   * An MFD defining multiple magnitudes with varying rates. This is only used
+   * in the 2008 California model where the rates of magnitudes above 6.5 were
+   * reduced by a fixed amount, yielding MFDs that no longer had a clean
+   * functional form.
+   */
   INCR;
 }

--- a/src/gov/usgs/earthquake/nshmp/mfd/Mfds.java
+++ b/src/gov/usgs/earthquake/nshmp/mfd/Mfds.java
@@ -49,7 +49,11 @@ public final class Mfds {
    *        {@code false} otherwise
    * @return a new {@code IncrementalMfd}
    */
-  public static IncrementalMfd newSingleMFD(double mag, double cumRate, boolean floats) {
+  public static IncrementalMfd newSingleMFD(
+      double mag,
+      double cumRate,
+      boolean floats) {
+
     IncrementalMfd mfd = buildIncrementalBaseMFD(mag, mag, 1, floats);
     mfd.set(mag, cumRate);
     return mfd;
@@ -64,7 +68,11 @@ public final class Mfds {
    *        {@code false} otherwise
    * @return a new {@code IncrementalMfd}
    */
-  public static IncrementalMfd newSingleMoBalancedMFD(double mag, double moRate, boolean floats) {
+  public static IncrementalMfd newSingleMoBalancedMFD(
+      double mag,
+      double moRate,
+      boolean floats) {
+
     double cumRate = moRate / magToMoment(mag);
     return newSingleMFD(mag, cumRate, floats);
   }
@@ -118,8 +126,13 @@ public final class Mfds {
    *        {@code false} otherwise
    * @return a new {@code GaussianMfd}
    */
-  public static GaussianMfd newGaussianMFD(double mean, double sigma, int size, double cumRate,
+  public static GaussianMfd newGaussianMFD(
+      double mean,
+      double sigma,
+      int size,
+      double cumRate,
       boolean floats) {
+
     GaussianMfd mfd = buildGaussianBaseMFD(mean, sigma, size, floats);
     mfd.setAllButTotMoRate(mean, sigma, cumRate, DEFAULT_TRUNC_LEVEL, DEFAULT_TRUNC_TYPE);
     return mfd;
@@ -138,8 +151,13 @@ public final class Mfds {
    *        {@code false} otherwise
    * @return a new {@code GaussianMfd}
    */
-  public static GaussianMfd newGaussianMoBalancedMFD(double mean, double sigma, int size,
-      double moRate, boolean floats) {
+  public static GaussianMfd newGaussianMoBalancedMFD(
+      double mean,
+      double sigma,
+      int size,
+      double moRate,
+      boolean floats) {
+
     GaussianMfd mfd = buildGaussianBaseMFD(mean, sigma, size, floats);
     mfd.setAllButCumRate(mean, sigma, moRate, DEFAULT_TRUNC_LEVEL, DEFAULT_TRUNC_TYPE);
     return mfd;
@@ -156,8 +174,13 @@ public final class Mfds {
    * @param cumRate total cumulative rate
    * @return a new {@code GutenbergRichterMfd}
    */
-  public static GutenbergRichterMfd newGutenbergRichterMFD(double min, double delta, int size,
-      double b, double cumRate) {
+  public static GutenbergRichterMfd newGutenbergRichterMFD(
+      double min,
+      double delta,
+      int size,
+      double b,
+      double cumRate) {
+
     GutenbergRichterMfd mfd = buildGutenbergRichterBaseMFD(min, delta, size);
     mfd.setAllButTotMoRate(min, min + (size - 1) * delta, cumRate, b);
     return mfd;
@@ -174,8 +197,13 @@ public final class Mfds {
    * @param moRate total moment rate
    * @return a new {@code GutenbergRichterMfd}
    */
-  public static GutenbergRichterMfd newGutenbergRichterMoBalancedMFD(double min, double delta,
-      int size, double b, double moRate) {
+  public static GutenbergRichterMfd newGutenbergRichterMoBalancedMFD(
+      double min,
+      double delta,
+      int size,
+      double b,
+      double moRate) {
+
     GutenbergRichterMfd mfd = buildGutenbergRichterBaseMFD(min, delta, size);
     mfd.setAllButTotCumRate(min, min + (size - 1) * delta, moRate, b);
     return mfd;
@@ -188,8 +216,15 @@ public final class Mfds {
    * factory method for now until MFD TODO Builders are impl.
    */
 
-  public static IncrementalMfd newTaperedGutenbergRichterMFD(double min, double delta, int size,
-      double a, double b, double corner, double weight) {
+  public static IncrementalMfd newTaperedGutenbergRichterMFD(
+      double min,
+      double delta,
+      int size,
+      double a,
+      double b,
+      double corner,
+      double weight) {
+
     GutenbergRichterMfd mfd = newGutenbergRichterMFD(min, delta, size, b, 1.0);
     double incrRate = incrRate(a, b, min) * weight;
     mfd.scaleToIncrRate(min, incrRate);
@@ -231,8 +266,13 @@ public final class Mfds {
    * Convenience method for computing the number of events in a tapered GR
    * magnitude bin.
    */
-  private static double magBinCount(double minMo, double magMoLo, double magMoHi, double beta,
+  private static double magBinCount(
+      double minMo,
+      double magMoLo,
+      double magMoHi,
+      double beta,
       double cornerMo) {
+
     return pareto(minMo, magMoLo, beta, cornerMo) - pareto(minMo, magMoHi, beta, cornerMo);
   }
 
@@ -240,7 +280,12 @@ public final class Mfds {
    * Complementary Pareto distribution: cumulative number of events with seismic
    * moment greater than magMo with an exponential taper
    */
-  private static double pareto(double minMo, double magMo, double beta, double cornerMo) {
+  private static double pareto(
+      double minMo,
+      double magMo,
+      double beta,
+      double cornerMo) {
+
     return pow(minMo / magMo, beta) * exp((minMo - magMo) / cornerMo);
   }
 
@@ -271,7 +316,13 @@ public final class Mfds {
    * @param b value
    * @return the total moment rate
    */
-  public static double totalMoRate(double mMin, int nMag, double dMag, double a, double b) {
+  public static double totalMoRate(
+      double mMin,
+      int nMag,
+      double dMag,
+      double a,
+      double b) {
+
     double moRate = 1e-10; // start with small, non-zero rate
     double M;
     for (int i = 0; i < nMag; i++) {

--- a/test/gov/usgs/earthquake/nshmp/eq/model/peer/PeerTest.java
+++ b/test/gov/usgs/earthquake/nshmp/eq/model/peer/PeerTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Ignore;
 import org.junit.Test;
+import org.xml.sax.SAXException;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
@@ -142,7 +143,8 @@ public class PeerTest {
         Double.valueOf(expected).equals(Double.valueOf(actual));
   }
 
-  static List<Object[]> load(String modelId, double tolerance) throws IOException {
+  static List<Object[]> load(String modelId, double tolerance) 
+      throws IOException, SAXException {
     Map<String, double[]> expectedsMap = loadExpecteds(modelId);
     HazardModel model = HazardModel.load(MODEL_DIR.resolve(modelId));
     CalcConfig config = model.config();

--- a/test/gov/usgs/earthquake/nshmp/eq/model/peer/PeerTests.java
+++ b/test/gov/usgs/earthquake/nshmp/eq/model/peer/PeerTests.java
@@ -5,6 +5,7 @@ import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -35,7 +36,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C1, TOL);
     }
   }
@@ -49,7 +50,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C2, TOL);
     }
   }
@@ -63,7 +64,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C2_F, TOL);
     }
   }
@@ -77,7 +78,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C3, TOL);
     }
   }
@@ -91,7 +92,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C3_F, TOL);
     }
   }
@@ -105,7 +106,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C4, TOL);
     }
   }
@@ -119,7 +120,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C4_F, TOL);
     }
   }
@@ -133,7 +134,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C5, TOL);
     }
   }
@@ -147,7 +148,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C5_F, TOL);
     }
   }
@@ -161,7 +162,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C6, TOL);
     }
   }
@@ -175,7 +176,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C6_F, TOL);
     }
   }
@@ -189,7 +190,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C7, TOL);
     }
   }
@@ -203,7 +204,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C7_F, TOL);
     }
   }
@@ -216,7 +217,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C8A, TOL);
     }
   }
@@ -229,8 +230,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data()
-        throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C8B, TOL);
     }
   }
@@ -243,7 +243,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C8C, TOL);
     }
   }
@@ -257,8 +257,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data()
-        throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C10, TOL);
     }
   }
@@ -272,7 +271,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S1_C10_F, TOL);
     }
   }
@@ -286,7 +285,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C2A, TOL);
     }
   }
@@ -300,7 +299,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C2A_F, TOL);
     }
   }
@@ -314,7 +313,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C2B, TOL);
     }
   }
@@ -328,7 +327,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C2B_F, TOL);
     }
   }
@@ -342,7 +341,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C2C, TOL);
     }
   }
@@ -356,7 +355,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C2C_F, TOL);
     }
   }
@@ -370,7 +369,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C2D, TOL);
     }
   }
@@ -384,7 +383,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C2D_F, TOL);
     }
   }
@@ -398,8 +397,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data()
-        throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C3A, TOL);
     }
   }
@@ -413,7 +411,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C3A_F, TOL);
     }
   }
@@ -427,7 +425,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C3B, TOL);
     }
   }
@@ -441,7 +439,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C3B_F, TOL);
     }
   }
@@ -455,7 +453,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C3C, TOL);
     }
   }
@@ -469,7 +467,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C3C_F, TOL);
     }
   }
@@ -483,7 +481,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C3D, TOL);
     }
   }
@@ -497,7 +495,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C3D_F, TOL);
     }
   }
@@ -511,7 +509,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C4A, TOL);
     }
   }
@@ -525,8 +523,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data()
-        throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C4A_F, TOL);
     }
   }
@@ -540,7 +537,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C4B, TOL);
     }
   }
@@ -554,7 +551,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C4B_F, TOL);
     }
   }
@@ -567,7 +564,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C5A, TOL);
     }
   }
@@ -580,7 +577,7 @@ public class PeerTests {
     }
 
     @Parameters(name = "{0}, Site{index}")
-    public static Collection<Object[]> data() throws IOException {
+    public static Collection<Object[]> data() throws IOException, SAXException {
       return load(S2_C5B, TOL);
     }
   }


### PR DESCRIPTION
In models, the Grid directory may have a 'sources' directory containing CSV location/rate/MFD properties/attributes to which XML source files can point via a `<nodes path="">` attribute. Error propagation is also improved in this PR. 

Resolves #261 
Resolves #272  