### PR TITLE
Ground Motion Vs. Distance Calculations

### DIFF
--- a/src/gov/usgs/earthquake/nshmp/GroundMotions.java
+++ b/src/gov/usgs/earthquake/nshmp/GroundMotions.java
@@ -8,9 +8,9 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+import com.google.common.primitives.Doubles;
 
 import gov.usgs.earthquake.nshmp.data.Data;
-import gov.usgs.earthquake.nshmp.eq.model.Distance;
 import gov.usgs.earthquake.nshmp.gmm.Gmm;
 import gov.usgs.earthquake.nshmp.gmm.GmmInput;
 import gov.usgs.earthquake.nshmp.gmm.Imt;
@@ -32,19 +32,16 @@ public class GroundMotions {
     
     
     //.............................. Set Distance and Gmm Inputs ..........................
-    double rJB;
+    int round = 5;
+  		double rJB;
     double rX;
     double rRup;
     double rMin = 0.001;
-    double rPoints = 20.0;
+    double rPoints = 100.0;
     double rStep = (Math.log10(rMax/rMin))/(rPoints-1);
-    double[] distanceLog = Data.buildSequence(
-        Math.log10(rMin), Math.log10(rMax), rStep, true);
-    double[] distance = Data.pow10(distanceLog.clone());
+    double[] distance = Data.round(round, Data.pow10(Data.buildSequence(
+        Math.log10(rMin), Math.log10(rMax), rStep, true)));
     
-    List<Double> rJBs = new ArrayList<>();
-    List<Double> rRups = new ArrayList<>();
-    List<Double> rXs = new ArrayList<>();
     List<GmmInput> gmmInputs = new ArrayList<>(); 
     
     for(double r : distance) {
@@ -53,9 +50,6 @@ public class GroundMotions {
       rRup = Maths.hypot(r, inputModel.zTop);
       GmmInput.Builder gmmBuilder = GmmInput.builder().fromModel(inputModel);
       gmmInputs.add(gmmBuilder.distances(rJB, rRup, rX).build());
-      rJBs.add(rJB);
-      rRups.add(rRup);
-      rXs.add(rX);
     }
     //-------------------------------------------------------------------------------------
     
@@ -68,23 +62,20 @@ public class GroundMotions {
     for(Gmm gmm : gmms) {
       ImmutableList.Builder<Double> means = ImmutableList.builder();
       ImmutableList.Builder<Double> sigmas = ImmutableList.builder();
-     
+           
       for(GmmInput gmmInput : gmmInputs) {
         ScalarGroundMotion gm = gmm.instance(imt).calc(gmmInput);
         means.add(gm.mean());
-        sigmas.add(gm.sigma());      
+        sigmas.add(gm.sigma()); 
       }
       
       meanMap.put(gmm, means.build());
       sigmaMap.put(gmm, sigmas.build());
-      distanceMap.put(gmm, rXs);
+      distanceMap.put(gmm, Doubles.asList(distance));
     }
     //-------------------------------------------------------------------------------------
     
     return new DistanceResult(
-        rJBs,
-        rRups,
-        rXs,
         Maps.immutableEnumMap(distanceMap),
         Maps.immutableEnumMap(meanMap),
         Maps.immutableEnumMap(sigmaMap)
@@ -97,23 +88,14 @@ public class GroundMotions {
   //............................. Class: DistanceResult ...................................
   public static class DistanceResult {
     
-    public final List<Double> rJBs;
-    public final List<Double> rRups;  
-    public final List<Double> rXs;
     public final Map<Gmm, List<Double>> means;
     public final Map<Gmm, List<Double>> distance;
     public final Map<Gmm, List<Double>> sigmas;
     
     DistanceResult(
-        List<Double> rJBs,
-        List<Double> rRups,
-        List<Double> rXs,
         Map<Gmm, List<Double>> distance,
         Map<Gmm, List<Double>> means,
         Map<Gmm, List<Double>> sigmas){
-      this.rJBs = rJBs;
-      this.rRups = rRups;
-      this.rXs = rXs;
       this.distance = distance;    
       this.means = means;
       this.sigmas = sigmas;

--- a/src/gov/usgs/earthquake/nshmp/GroundMotions.java
+++ b/src/gov/usgs/earthquake/nshmp/GroundMotions.java
@@ -1,0 +1,127 @@
+package gov.usgs.earthquake.nshmp;
+
+//....................................... Import ..........................................
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+
+import gov.usgs.earthquake.nshmp.data.Data;
+import gov.usgs.earthquake.nshmp.eq.model.Distance;
+import gov.usgs.earthquake.nshmp.gmm.Gmm;
+import gov.usgs.earthquake.nshmp.gmm.GmmInput;
+import gov.usgs.earthquake.nshmp.gmm.Imt;
+import gov.usgs.earthquake.nshmp.gmm.ScalarGroundMotion;
+import gov.usgs.earthquake.nshmp.util.Maths;
+//--------------------------------------- End Import --------------------------------------
+
+
+
+public class GroundMotions {
+  
+  
+  //................................ Method: distanceGroundMotion .........................
+  public static DistanceResult distanceGroundMotions(
+      Set<Gmm> gmms,
+      GmmInput inputModel,
+      Imt imt,
+      double rMax) {
+    
+    
+    //.............................. Set Distance and Gmm Inputs ..........................
+    double rJB;
+    double rX;
+    double rRup;
+    double rMin = 0.001;
+    double rPoints = 20.0;
+    double rStep = (Math.log10(rMax/rMin))/(rPoints-1);
+    double[] distanceLog = Data.buildSequence(
+        Math.log10(rMin), Math.log10(rMax), rStep, true);
+    double[] distance = Data.pow10(distanceLog.clone());
+    
+    List<Double> rJBs = new ArrayList<>();
+    List<Double> rRups = new ArrayList<>();
+    List<Double> rXs = new ArrayList<>();
+    List<GmmInput> gmmInputs = new ArrayList<>(); 
+    
+    for(double r : distance) {
+      rJB = r;
+      rX = r;
+      rRup = Maths.hypot(r, inputModel.zTop);
+      GmmInput.Builder gmmBuilder = GmmInput.builder().fromModel(inputModel);
+      gmmInputs.add(gmmBuilder.distances(rJB, rRup, rX).build());
+      rJBs.add(rJB);
+      rRups.add(rRup);
+      rXs.add(rX);
+    }
+    //-------------------------------------------------------------------------------------
+    
+    
+    //........................... Calculate Ground Motion .................................
+    Map<Gmm, List<Double>> distanceMap = Maps.newEnumMap(Gmm.class);
+    Map<Gmm, List<Double>> meanMap = Maps.newEnumMap(Gmm.class);
+    Map<Gmm, List<Double>> sigmaMap = Maps.newEnumMap(Gmm.class);
+    
+    for(Gmm gmm : gmms) {
+      ImmutableList.Builder<Double> means = ImmutableList.builder();
+      ImmutableList.Builder<Double> sigmas = ImmutableList.builder();
+     
+      for(GmmInput gmmInput : gmmInputs) {
+        ScalarGroundMotion gm = gmm.instance(imt).calc(gmmInput);
+        means.add(gm.mean());
+        sigmas.add(gm.sigma());      
+      }
+      
+      meanMap.put(gmm, means.build());
+      sigmaMap.put(gmm, sigmas.build());
+      distanceMap.put(gmm, rXs);
+    }
+    //-------------------------------------------------------------------------------------
+    
+    return new DistanceResult(
+        rJBs,
+        rRups,
+        rXs,
+        Maps.immutableEnumMap(distanceMap),
+        Maps.immutableEnumMap(meanMap),
+        Maps.immutableEnumMap(sigmaMap)
+    );
+  }
+  //------------------------------ End Method: distanceGroundMotion -----------------------
+  
+  
+  
+  //............................. Class: DistanceResult ...................................
+  public static class DistanceResult {
+    
+    public final List<Double> rJBs;
+    public final List<Double> rRups;  
+    public final List<Double> rXs;
+    public final Map<Gmm, List<Double>> means;
+    public final Map<Gmm, List<Double>> distance;
+    public final Map<Gmm, List<Double>> sigmas;
+    
+    DistanceResult(
+        List<Double> rJBs,
+        List<Double> rRups,
+        List<Double> rXs,
+        Map<Gmm, List<Double>> distance,
+        Map<Gmm, List<Double>> means,
+        Map<Gmm, List<Double>> sigmas){
+      this.rJBs = rJBs;
+      this.rRups = rRups;
+      this.rXs = rXs;
+      this.distance = distance;    
+      this.means = means;
+      this.sigmas = sigmas;
+    }
+  }
+  //------------------------------ End Class: DistanceResult ------------------------------
+
+  
+  
+}
+//-------------------------------- End Class: GroundMotions -------------------------------

--- a/src/gov/usgs/earthquake/nshmp/gmm/GmmInput.java
+++ b/src/gov/usgs/earthquake/nshmp/gmm/GmmInput.java
@@ -198,6 +198,7 @@ public class GmmInput {
       return b;
     }
     
+    
     /**
      * Return a {@code Builder} prepopulated with default values. Builder has
      * the following presets:

--- a/src/gov/usgs/earthquake/nshmp/gmm/GmmInput.java
+++ b/src/gov/usgs/earthquake/nshmp/gmm/GmmInput.java
@@ -194,7 +194,7 @@ public class GmmInput {
       b.vsInf = model.vsInf;
       b.z1p0 = model.z1p0;
       b.z2p5 = model.z2p5;
-      flags.set(0, SIZE);
+      b.flags.set(0, SIZE);
       return b;
     }
     


### PR DESCRIPTION
## Ground motion Vs. distance calculations

### GroundMotions.java
- Condition: New file
- Location: nshmp-haz/src/gov/usgs/earthquake/nshmp
- Purpose: To calculate ground motion vs. distance given a GmmInput model. 

#### Notes:
- Simple calculation is done for rRup assuming a vertical fault
- The minimum distance is defined to 0.001  km
- The number of points for distance is defined to 100
- The maximum distance is defined in the gmm-distance web page at 300 km