### PR TITLE
Weighted sums and GM combining

### DIFF
--- a/src/gov/usgs/earthquake/nshmp/data/Data.java
+++ b/src/gov/usgs/earthquake/nshmp/data/Data.java
@@ -51,8 +51,8 @@ import gov.usgs.earthquake.nshmp.util.Maths;
  * <li>Do not check for finiteness (see {@link Doubles#isFinite(double)}). For
  * example, any method that operates on data containing {@code Double.NaN} or
  * infinite values will likely return {@code NaN}s or infinite values as a
- * result. See the Java {@link Math} class for details on the behavior of
- * individual functions referenced herein.</li>
+ * result. See the Java {@link Math} for details on the behavior of individual
+ * functions referenced herein.</li>
  *
  * <li>Do not check for over/under flow.</li></ul>
  *
@@ -70,8 +70,6 @@ import gov.usgs.earthquake.nshmp.util.Maths;
  * @author Peter Powers
  */
 public final class Data {
-
-  // TODO consider weighted sum
 
   /*
    * Developer notes:
@@ -608,6 +606,41 @@ public final class Data {
   }
 
   /**
+   * Compute the weighted sum of the supplied data. Weights are not constrained
+   * to sum to 1.0.
+   * 
+   * @param data to sum
+   * @param weights to apply
+   * @return the weighted sum of the supplied values
+   */
+  public static double weightedSum(double[] data, double[] weights) {
+    checkSizes(data, weights);
+    double sum = 0.0;
+    for (int i = 0; i < data.length; i++) {
+      sum += data[i] * weights[i];
+    }
+    return sum;
+  }
+
+  /**
+   * Compute a weighted sum of the supplied data in linear space, given data
+   * that is in natural log space. Returned sum is in natural log space. Weights
+   * are not constrained to sum to 1.0.
+   * 
+   * @param data to sum (natural log values)
+   * @param weights to apply
+   * @return the weighted sum of the supplied values
+   */
+  public static double weightedSumLn(double[] data, double[] weights) {
+    checkSizes(data, weights);
+    double sum = 0.0;
+    for (int i = 0; i < data.length; i++) {
+      sum += Math.exp(data[i]) * weights[i];
+    }
+    return Math.log(sum);
+  }
+
+  /**
    * Sum the arrays in the 2nd dimension of {@code data} into a new 1-D array.
    * 
    * @param data to collapse
@@ -635,6 +668,19 @@ public final class Data {
       collapsed[i] = collapse(data[i]);
     }
     return collapsed;
+  }
+
+  /**
+   * Cumulate the values of {@code data} in place.
+   * 
+   * @param data to operate on
+   * @return a reference to the supplied {@code data}
+   */
+  public static double[] cumulate(double... data) {
+    for (int i = 1; i < data.length; i++) {
+      data[i] += data[i - 1];
+    }
+    return data;
   }
 
   /**
@@ -851,19 +897,6 @@ public final class Data {
       return 0;
     }
     return Math.abs(test - target) / target * 100.0;
-  }
- 
-  /**
-   * Cumulate the values of {@code data} in place.
-   * 
-   * @param data to operate on
-   * @return a reference to the supplied {@code data}
-   */
-  public static double[] cumulate(double... data) {
-    for (int i=1; i<data.length; i++) {
-      data[i] += data[i-1];
-    }
-    return data;
   }
 
   /* * * * * * * * * * * * * * STATE * * * * * * * * * * * * * */
@@ -1250,10 +1283,11 @@ public final class Data {
   public static Collection<Double> checkWeights(Collection<Double> weights) {
     return checkWeights(weights, true);
   }
-  
+
   /**
    * Ensure each {@code 0.0 ≤ weight ≤ 1.0} and
-   * {@code sum(weights) = 1.0 ± 0.0001}, optionally allowing zero-valued weights.
+   * {@code sum(weights) = 1.0 ± 0.0001}, optionally allowing zero-valued
+   * weights.
    *
    * @param weights to validate
    * @return a reference to the supplied {@code weights}
@@ -1261,7 +1295,7 @@ public final class Data {
   public static Collection<Double> checkWeights(
       Collection<Double> weights,
       boolean allowZero) {
-    
+
     for (double weight : weights) {
       checkWeight(weight, allowZero);
     }
@@ -1270,10 +1304,11 @@ public final class Data {
         "Weights Σ %s = %s ≠ 1.0", weights, sum);
     return weights;
   }
-  
+
   /**
    * Ensure each {@code 0.0 ≤ weight ≤ 1.0} and
-   * {@code sum(weights) = 1.0 ± 0.0001}, optionally allowing zero-valued weights.
+   * {@code sum(weights) = 1.0 ± 0.0001}, optionally allowing zero-valued
+   * weights.
    *
    * @param weights to validate
    * @return a reference to the supplied {@code weights}
@@ -1282,15 +1317,15 @@ public final class Data {
     for (double weight : weights) {
       checkWeight(weight, allowZero);
     }
-    
+
     double sum = sum(weights);
-    
+
     checkArgument(DoubleMath.fuzzyEquals(sum, 1.0, WEIGHT_TOLERANCE),
         "Weights Σ %s = %s ≠ 1.0", weights, sum);
-    
+
     return weights;
   }
-  
+
   /**
    * Ensure each {@code 0.0 ≤ weight ≤ 1.0} and
    * {@code sum(weights) = 1.0 ± 0.0001}. This method permits zero-valued
@@ -1302,8 +1337,6 @@ public final class Data {
   public static double[] checkWeights(double[] weights) {
     return checkWeights(weights, true);
   }
-
-  
 
   /* * * * * * * * 2D & 3D ARRAYS EXTENSIONS * * * * * * * * */
 

--- a/src/gov/usgs/earthquake/nshmp/gmm/CombinedGmm.java
+++ b/src/gov/usgs/earthquake/nshmp/gmm/CombinedGmm.java
@@ -48,15 +48,19 @@ class CombinedGmm implements GroundMotionModel {
             entry -> entry.getKey().calc(in),
             Map.Entry::getValue));
 
+    /*
+     * Mean values are converted to linear space for combining and returned to
+     * natural log space upon return.
+     */
     double μ = sgms.entrySet().stream()
         .collect(Collectors.summingDouble(
-            entry -> entry.getKey().mean() * entry.getValue()));
+            entry -> Math.exp(entry.getKey().mean()) * entry.getValue()));
 
     double σ = sgms.entrySet().stream()
         .collect(Collectors.summingDouble(
             entry -> entry.getKey().sigma() * entry.getValue()));
 
-    return DefaultScalarGroundMotion.create(μ, σ);
+    return DefaultScalarGroundMotion.create(Math.log(μ), σ);
   }
 
   private static Map<GroundMotionModel, Double> imtToInstances(
@@ -127,7 +131,7 @@ class CombinedGmm implements GroundMotionModel {
       super(imtToInstances(imt, CEUS_2018));
     }
   }
-  
+
   private static final Map<Gmm, Double> WUS_2014_4P1 = ImmutableMap.<Gmm, Double> builder()
       .put(ASK_14, 0.22)
       .put(BSSA_14, 0.22)

--- a/src/gov/usgs/earthquake/nshmp/gmm/MultiScalarGroundMotion.java
+++ b/src/gov/usgs/earthquake/nshmp/gmm/MultiScalarGroundMotion.java
@@ -32,8 +32,8 @@ public class MultiScalarGroundMotion extends DefaultScalarGroundMotion {
       double[] sigmas, double[] sigmaWts) {
 
     super(
-        Data.sum(Data.multiply(Arrays.copyOf(means, means.length), meanWts)),
-        Data.sum(Data.multiply(Arrays.copyOf(sigmas, sigmas.length), sigmaWts)));
+        Data.weightedSumLn(means, meanWts),
+        Data.weightedSum(sigmas, sigmaWts));
 
     this.means = means;
     this.meanWts = meanWts;

--- a/test/gov/usgs/earthquake/nshmp/data/DataTests.java
+++ b/test/gov/usgs/earthquake/nshmp/data/DataTests.java
@@ -30,7 +30,7 @@ public final class DataTests {
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
-  
+
   private static final double[] VALUES = { 1.0, 10.0, 100.0 };
 
   private static double[] valueArray() {
@@ -351,6 +351,19 @@ public final class DataTests {
   }
 
   @Test
+  public final void testWeightedSum() {
+    double[] weights = { 0.2, 0.1, 0.5, 0.2 };
+    double[] linData = { 3.0, 1.0, 2.0, 4.0 };
+    double[] logData = Data.ln(Arrays.copyOf(linData, linData.length));
+    // linear
+    double linExpect = 2.5;
+    assertEquals(linExpect, Data.weightedSum(linData, weights), 0.0);
+    // log
+    double logExpect = Math.log(linExpect);
+    assertEquals(logExpect, Data.weightedSumLn(logData, weights), 0.0);
+  }
+
+  @Test
   public final void testCollapse() {
     // 2D
     double[] d2_expect = { 111.0, 111.0 };
@@ -367,52 +380,67 @@ public final class DataTests {
   }
 
   @Test
+  public final void testCumulate() {
+    double[] data = { 0.0, 2.0, 4.0, 6.0, 8.0 };
+    double[] expected = { 0.0, 2.0, 6.0, 12.0, 20.0 };
+    assertArrayEquals(expected, Data.cumulate(data), 0.0);
+  }
+
+  @Test
   public final void testTransform() {
-    DoubleUnaryOperator function = (x) -> { return x + 1; };
-    
+    DoubleUnaryOperator function = (x) -> {
+      return x + 1;
+    };
+
     double[] expectArray = { 2.0, 11.0, 101.0 };
     double[] actualArray = Data.transform(function, valueArray());
     List<Double> actualList = Data.transform(function, valueList());
     testArrayAndList(expectArray, actualArray, actualList);
   }
-  
+
   @Test
   public final void testTransformRange() {
-    DoubleUnaryOperator function = (x) -> { return x + 1; };
-    
+    DoubleUnaryOperator function = (x) -> {
+      return x + 1;
+    };
+
     Range<Integer> range = Range.closed(0, 1);
     double[] expect = { 2.0, 11.0, 100.0 };
     double[] actual1 = Data.transform(range, function, valueArray());
     double[] actual2 = Data.transform(0, 2, function, valueArray());
-    
+
     assertArrayEquals(expect, actual1, 0.0);
     assertArrayEquals(expect, actual2, 0.0);
   }
-  
+
   @Test
   public final void testTransformIAE() {
     exception.expect(IllegalArgumentException.class);
- 
+
     Range<Integer> range = Range.openClosed(0, 0);
-    Data.transform(range, (x) -> { return x; }, valueArray());
+    Data.transform(range, (x) -> {
+      return x;
+    }, valueArray());
   }
-  
+
   @Test
   public final void testTransformIAE2() {
     exception.expect(IllegalArgumentException.class);
-    
+
     Range<Integer> range = Range.atMost(1);
-    Data.transform(range, (x) -> { return x; }, valueArray());
+    Data.transform(range, (x) -> {
+      return x;
+    }, valueArray());
   }
-  
+
   @Test
   public final void testTransformNPE() {
     exception.expect(NullPointerException.class);
-    
+
     Range<Integer> range = Range.closed(0, 1);
     Data.transform(range, null, valueArray());
   }
-  
+
   @Test
   public final void testNormalize() {
     double[] expectArray = { 0.2, 0.3, 0.5 };
@@ -646,7 +674,7 @@ public final class DataTests {
   public final void testCheckWeight() {
     assertEquals(0.5, Data.checkWeight(0.5), 0.0);
   }
-  
+
   @Test(expected = IllegalArgumentException.class)
   public final void testCheckWeight_IAE() {
     Data.checkWeight(0.0);


### PR DESCRIPTION
Weighted sums of ground motions for CombinedGmm and MultiScalarGroundMotion are now computed in linear instead of natural log space.