### PR TITLE
GeoJSON nulls

### DIFF
--- a/src/gov/usgs/earthquake/nshmp/geo/json/Feature.java
+++ b/src/gov/usgs/earthquake/nshmp/geo/json/Feature.java
@@ -204,7 +204,7 @@ public class Feature {
      * @return this builder
      */
     public Builder properties(Map<String, Object> properties) {
-      this.properties = Collections.unmodifiableMap(new LinkedHashMap<String, Object>(properties)); 
+      this.properties = Collections.unmodifiableMap(new LinkedHashMap<String, Object>(properties));
       return this;
     }
 

--- a/src/gov/usgs/earthquake/nshmp/geo/json/Feature.java
+++ b/src/gov/usgs/earthquake/nshmp/geo/json/Feature.java
@@ -3,6 +3,8 @@ package gov.usgs.earthquake.nshmp.geo.json;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
@@ -202,7 +204,7 @@ public class Feature {
      * @return this builder
      */
     public Builder properties(Map<String, Object> properties) {
-      this.properties = ImmutableMap.copyOf(properties);
+      this.properties = Collections.unmodifiableMap(new LinkedHashMap<String, Object>(properties)); 
       return this;
     }
 

--- a/src/gov/usgs/earthquake/nshmp/geo/json/GeoJson.java
+++ b/src/gov/usgs/earthquake/nshmp/geo/json/GeoJson.java
@@ -121,6 +121,7 @@ public final class GeoJson {
           new Util.Serializer<>(GeoJson.Type.converter()))
       .setPrettyPrinting()
       .disableHtmlEscaping()
+      .serializeNulls()
       .create();
 
   /**

--- a/src/gov/usgs/earthquake/nshmp/geo/json/Properties.java
+++ b/src/gov/usgs/earthquake/nshmp/geo/json/Properties.java
@@ -2,12 +2,12 @@ package gov.usgs.earthquake.nshmp.geo.json;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Converter;
-import com.google.common.collect.ImmutableMap;
 
 /**
  * GeoJSON properties helper class.
@@ -161,7 +161,7 @@ public final class Properties {
      * Return an immutable map reflecting the current contents of this builder.
      */
     public Map<String, Object> build() {
-      return ImmutableMap.copyOf(map);
+      return Collections.unmodifiableMap(new LinkedHashMap<String, Object>(map)); 
     }
   }
 

--- a/src/gov/usgs/earthquake/nshmp/geo/json/Properties.java
+++ b/src/gov/usgs/earthquake/nshmp/geo/json/Properties.java
@@ -161,7 +161,7 @@ public final class Properties {
      * Return an immutable map reflecting the current contents of this builder.
      */
     public Map<String, Object> build() {
-      return Collections.unmodifiableMap(new LinkedHashMap<String, Object>(map)); 
+      return Collections.unmodifiableMap(new LinkedHashMap<String, Object>(map));
     }
   }
 


### PR DESCRIPTION
* `ImmutableMap.copyOf` doesn't allow null values, changed to `Collections.unmodifiableMap` for Properties
* Added `serializeNulls` to Gson

NOTE:
The side effect of this is that `bbox` is generally null and will get printed out