### PR TITLE
Gmm Test

### DIFF
--- a/test/gov/usgs/earthquake/nshmp/gmm/CeusHardRock.java
+++ b/test/gov/usgs/earthquake/nshmp/gmm/CeusHardRock.java
@@ -23,23 +23,13 @@ public class CeusHardRock extends GmmTest {
   private static String GMM_INPUTS = "CEUS_vs2000_inputs.csv";
   private static String GMM_RESULTS = "CEUS_vs2000_results.csv";
 
-  static {
-    try {
-      inputsList = loadInputs(GMM_INPUTS);
-    } catch (IOException ioe) {
-      ioe.printStackTrace();
-      System.exit(1);
-    }
-  }
-
   @Parameters(name = "{index}: {0} {2} {1}")
-  public static Collection<Object[]> data()
-      throws IOException {
+  public static Collection<Object[]> data() throws IOException {
     return loadResults(GMM_RESULTS);
   }
 
   public CeusHardRock(int index, Gmm gmm, Imt imt, double exMedian, double exSigma) {
-    super(index, gmm, imt, exMedian, exSigma);
+    super(index, gmm, imt, exMedian, exSigma, GMM_INPUTS);
   }
 
   /* Result generation sets */

--- a/test/gov/usgs/earthquake/nshmp/gmm/CeusSoftRock.java
+++ b/test/gov/usgs/earthquake/nshmp/gmm/CeusSoftRock.java
@@ -23,23 +23,13 @@ public class CeusSoftRock extends GmmTest {
   private static String GMM_INPUTS = "CEUS_vs760_inputs.csv";
   private static String GMM_RESULTS = "CEUS_vs760_results.csv";
 
-  static {
-    try {
-      inputsList = loadInputs(GMM_INPUTS);
-    } catch (IOException ioe) {
-      ioe.printStackTrace();
-      System.exit(1);
-    }
-  }
-
   @Parameters(name = "{index}: {0} {2} {1}")
-  public static Collection<Object[]> data()
-      throws IOException {
+  public static Collection<Object[]> data() throws IOException {
     return loadResults(GMM_RESULTS);
   }
 
   public CeusSoftRock(int index, Gmm gmm, Imt imt, double exMedian, double exSigma) {
-    super(index, gmm, imt, exMedian, exSigma);
+    super(index, gmm, imt, exMedian, exSigma, GMM_INPUTS);
   }
 
   /* Result generation sets */

--- a/test/gov/usgs/earthquake/nshmp/gmm/GmmTest.java
+++ b/test/gov/usgs/earthquake/nshmp/gmm/GmmTest.java
@@ -29,21 +29,27 @@ public abstract class GmmTest {
 
   private static final String DATA_DIR = "data/";
   private static final double TOL = 1e-6;
-  static List<GmmInput> inputsList;
 
   private int index;
   private Gmm gmm;
   private Imt imt;
   private double exMedian;
   private double exSigma;
+  private List<GmmInput> inputsList;
 
-  GmmTest(int index, Gmm gmm, Imt imt, double exMedian, double exSigma) {
-
+  GmmTest(int index, Gmm gmm, Imt imt, double exMedian, double exSigma, String gmmInputs) {
     this.index = index;
     this.gmm = gmm;
     this.imt = imt;
     this.exMedian = exMedian;
     this.exSigma = exSigma;
+    
+    try {
+      inputsList = loadInputs(gmmInputs);
+    } catch (IOException ioe) {
+      ioe.printStackTrace();
+      System.exit(1);
+    }
   }
 
   @Test

--- a/test/gov/usgs/earthquake/nshmp/gmm/LegacySoftRock.java
+++ b/test/gov/usgs/earthquake/nshmp/gmm/LegacySoftRock.java
@@ -30,23 +30,13 @@ public class LegacySoftRock extends GmmTest {
   private static String GMM_INPUTS = "CEUS_vs760_inputs.csv";
   private static String GMM_RESULTS = "LEGACY_vs760_results.csv";
 
-  static {
-    try {
-      inputsList = loadInputs(GMM_INPUTS);
-    } catch (IOException ioe) {
-      ioe.printStackTrace();
-      System.exit(1);
-    }
-  }
-
   @Parameters(name = "{index}: {0} {2} {1}")
-  public static Collection<Object[]> data()
-      throws IOException {
+  public static Collection<Object[]> data() throws IOException {
     return loadResults(GMM_RESULTS);
   }
 
   public LegacySoftRock(int index, Gmm gmm, Imt imt, double exMedian, double exSigma) {
-    super(index, gmm, imt, exMedian, exSigma);
+    super(index, gmm, imt, exMedian, exSigma, GMM_INPUTS);
   }
 
   /* Result generation sets */

--- a/test/gov/usgs/earthquake/nshmp/gmm/Ngaw1.java
+++ b/test/gov/usgs/earthquake/nshmp/gmm/Ngaw1.java
@@ -25,23 +25,13 @@ public class Ngaw1 extends GmmTest {
   private static String GMM_INPUTS = "NGA_inputs.csv";
   private static String GMM_RESULTS = "NGAW1_results.csv";
 
-  static {
-    try {
-      inputsList = loadInputs(GMM_INPUTS);
-    } catch (IOException ioe) {
-      ioe.printStackTrace();
-      System.exit(1);
-    }
-  }
-
   @Parameters(name = "{index}: {0} {2} {1}")
-  public static Collection<Object[]> data()
-      throws IOException {
+  public static Collection<Object[]> data() throws IOException {
     return loadResults(GMM_RESULTS);
   }
 
   public Ngaw1(int index, Gmm gmm, Imt imt, double exMedian, double exSigma) {
-    super(index, gmm, imt, exMedian, exSigma);
+    super(index, gmm, imt, exMedian, exSigma, GMM_INPUTS);
   }
 
   /* Result generation sets */

--- a/test/gov/usgs/earthquake/nshmp/gmm/Ngaw2.java
+++ b/test/gov/usgs/earthquake/nshmp/gmm/Ngaw2.java
@@ -27,23 +27,13 @@ public class Ngaw2 extends GmmTest {
   private static String GMM_INPUTS = "NGA_inputs.csv";
   private static String GMM_RESULTS = "NGAW2_results.csv";
 
-  static {
-    try {
-      inputsList = loadInputs(GMM_INPUTS);
-    } catch (IOException ioe) {
-      ioe.printStackTrace();
-      System.exit(1);
-    }
-  }
-
   @Parameters(name = "{index}: {0} {2} {1}")
-  public static Collection<Object[]> data()
-      throws IOException {
+  public static Collection<Object[]> data() throws IOException {
     return loadResults(GMM_RESULTS);
   }
 
   public Ngaw2(int index, Gmm gmm, Imt imt, double exMedian, double exSigma) {
-    super(index, gmm, imt, exMedian, exSigma);
+    super(index, gmm, imt, exMedian, exSigma, GMM_INPUTS);
   }
 
   /* Result generation sets */

--- a/test/gov/usgs/earthquake/nshmp/gmm/SubInterface.java
+++ b/test/gov/usgs/earthquake/nshmp/gmm/SubInterface.java
@@ -27,23 +27,13 @@ public class SubInterface extends GmmTest {
   private static String GMM_INPUTS = "INTERFACE_inputs.csv";
   private static String GMM_RESULTS = "INTERFACE_results.csv";
 
-  static {
-    try {
-      inputsList = loadInputs(GMM_INPUTS);
-    } catch (IOException ioe) {
-      ioe.printStackTrace();
-      System.exit(1);
-    }
-  }
-
   @Parameters(name = "{index}: {0} {2} {1}")
-  public static Collection<Object[]> data()
-      throws IOException {
+  public static Collection<Object[]> data() throws IOException {
     return loadResults(GMM_RESULTS);
   }
 
   public SubInterface(int index, Gmm gmm, Imt imt, double exMedian, double exSigma) {
-    super(index, gmm, imt, exMedian, exSigma);
+    super(index, gmm, imt, exMedian, exSigma, GMM_INPUTS);
   }
 
   /* Result generation sets */

--- a/test/gov/usgs/earthquake/nshmp/gmm/SubSlab.java
+++ b/test/gov/usgs/earthquake/nshmp/gmm/SubSlab.java
@@ -28,23 +28,13 @@ public class SubSlab extends GmmTest {
   private static String GMM_INPUTS = "SLAB_inputs.csv";
   private static String GMM_RESULTS = "SLAB_results.csv";
 
-  static {
-    try {
-      inputsList = loadInputs(GMM_INPUTS);
-    } catch (IOException ioe) {
-      ioe.printStackTrace();
-      System.exit(1);
-    }
-  }
-
   @Parameters(name = "{index}: {0} {2} {1}")
-  public static Collection<Object[]> data()
-      throws IOException {
+  public static Collection<Object[]> data() throws IOException {
     return loadResults(GMM_RESULTS);
   }
 
   public SubSlab(int index, Gmm gmm, Imt imt, double exMedian, double exSigma) {
-    super(index, gmm, imt, exMedian, exSigma);
+    super(index, gmm, imt, exMedian, exSigma, GMM_INPUTS);
   }
 
   /* Result generation sets */


### PR DESCRIPTION
* `inputsList` in `GmmTest` in no longer static
* `loadInputs` is now conducted in the constructor of `GmmTest`

When running `GmmTest`, all static methods for all gmm tests were ran first followed by the actual tests. This was problematic as the tests were being conducted with the last static call to `inputsList = loadInputs`. Thus the `inputsList` was not correct for each test and the tests failed.