### PR TITLE
Install File in Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG jar_path=${builder_workdir}/build/libs/${project}.jar
 #   - Download models (docker-builder-entrypoint.sh)
 #   - Build nshmp-haz
 ####
-FROM openjdk:8-alpine as builder
+FROM usgsnshmp/nshmp-openjdk:jdk8 as builder
 
 # Get builder workdir
 ARG builder_workdir
@@ -38,8 +38,8 @@ WORKDIR ${builder_workdir}
 # Copy project over to container
 COPY . ${builder_workdir}/. 
 
-# Install git, curl, and bash
-RUN apk add --no-cache git curl bash
+# Install git
+RUN yum install -y git
 
 # Build nshmp-haz
 RUN ./gradlew assemble

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG builder_workdir=/app/${project}
 ARG jar_path=${builder_workdir}/build/libs/${project}.jar
 
 ####
-# Builder Image: Java 8
+# Builder Image: Java 8 in usgs/centos image
 #   - Install git, curl, and bash
 #   - Download models (docker-builder-entrypoint.sh)
 #   - Build nshmp-haz

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,8 @@ LABEL maintainer="Peter Powers <pmpowers@usgs.gov>"
 # Set working directory
 WORKDIR /app
 
-# Install jq
-RUN yum install -y add epel-release
+# Install file and jq
+RUN yum install -y add file epel-release
 RUN yum install -y jq
 
 # Get JAR path


### PR DESCRIPTION
`file` was not installed by default in the `usgs/centos` Docker image. Thus nshmp-haz would fault out when encountering a CSV file when running in the Docker container.