### PR TITLE
Removed batch result writing

### DIFF
--- a/src/gov/usgs/earthquake/nshmp/DeaggCalc.java
+++ b/src/gov/usgs/earthquake/nshmp/DeaggCalc.java
@@ -140,19 +140,19 @@ public class DeaggCalc {
 
     log.info(PROGRAM + ": calculating ...");
 
-    HazardExport handler = HazardExport.create(config, sites, log);
+    HazardExport handler = HazardExport.create(model, config, sites, log);
 
     for (Site site : sites) {
       Hazard hazard = HazardCalcs.hazard(model, config, site, exec);
       Deaggregation deagg = HazardCalcs.deaggReturnPeriod(hazard, returnPeriod, exec);
-      handler.add(hazard, Optional.of(deagg));
+      handler.write(hazard, Optional.of(deagg));
       log.fine(hazard.toString());
     }
     handler.expire();
 
     log.info(String.format(
         PROGRAM + ": %s sites completed in %s",
-        handler.resultsProcessed(), handler.elapsedTime()));
+        handler.resultCount(), handler.elapsedTime()));
 
     exec.shutdown();
     return handler.outputDir();

--- a/src/gov/usgs/earthquake/nshmp/DeaggIml.java
+++ b/src/gov/usgs/earthquake/nshmp/DeaggIml.java
@@ -141,19 +141,19 @@ public class DeaggIml {
 
     log.info(PROGRAM + ": calculating ...");
 
-    HazardExport handler = HazardExport.create(config, sites, log);
+    HazardExport handler = HazardExport.create(model, config, sites, log);
 
     for (Site site : sites) {
       Hazard hazard = HazardCalcs.hazard(model, config, site, exec);
       Deaggregation deagg = HazardCalcs.deaggIml(hazard, iml, exec);
-      handler.add(hazard, Optional.of(deagg));
+      handler.write(hazard, Optional.of(deagg));
       log.fine(hazard.toString());
     }
     handler.expire();
 
     log.info(String.format(
         PROGRAM + ": %s sites completed in %s",
-        handler.resultsProcessed(), handler.elapsedTime()));
+        handler.resultCount(), handler.elapsedTime()));
 
     exec.shutdown();
     return handler.outputDir();

--- a/src/gov/usgs/earthquake/nshmp/Hazard2018.java
+++ b/src/gov/usgs/earthquake/nshmp/Hazard2018.java
@@ -154,7 +154,7 @@ public class Hazard2018 {
     final ExecutorService exec = initExecutor(threadCount);
     log.info("Threads: " + ((ThreadPoolExecutor) exec).getCorePoolSize());
 
-    HazardExport handler = HazardExport.create(models.wusConfig, sites, log);
+    HazardExport handler = HazardExport.create(models.wusModel, models.wusConfig, sites, log);
 
     log.info(PROGRAM + ": calculating ...");
 
@@ -173,7 +173,7 @@ public class Hazard2018 {
     exec.shutdown();
     log.info(String.format(
         PROGRAM + ": %s sites completed in %s",
-        handler.resultsProcessed(), handler.elapsedTime()));
+        handler.resultCount(), handler.elapsedTime()));
 
     return outputDir;
   }
@@ -218,7 +218,7 @@ public class Hazard2018 {
 
     @Override
     public Path call() throws IOException {
-      handler.add(hazard);
+      handler.write(hazard);
       return handler.outputDir();
     }
 

--- a/src/gov/usgs/earthquake/nshmp/HazardCalc.java
+++ b/src/gov/usgs/earthquake/nshmp/HazardCalc.java
@@ -165,17 +165,17 @@ public class HazardCalc {
 
     log.info(PROGRAM + ": calculating ...");
 
-    HazardExport handler = HazardExport.create(config, sites, log);
+    HazardExport handler = HazardExport.create(model, config, sites, log);
     for (Site site : sites) {
       Hazard hazard = HazardCalcs.hazard(model, config, site, exec);
-      handler.add(hazard, Optional.empty());
+      handler.write(hazard);
       log.fine(hazard.toString());
     }
     handler.expire();
 
     log.info(String.format(
         PROGRAM + ": %s sites completed in %s",
-        handler.resultsProcessed(), handler.elapsedTime()));
+        handler.resultCount(), handler.elapsedTime()));
 
     exec.shutdown();
     return handler.outputDir();

--- a/src/gov/usgs/earthquake/nshmp/calc/CalcConfig.java
+++ b/src/gov/usgs/earthquake/nshmp/calc/CalcConfig.java
@@ -943,52 +943,37 @@ public final class CalcConfig {
      */
     public final Set<DataType> dataTypes;
 
-    /**
-     * The number of results (one per {@code Site}) to store before writing to
-     * file(s). A larger number requires more memory.
-     *
-     * <p><b>Default:</b> {@code 1}
-     */
-    @Deprecated
-    public final int flushLimit;
-
     private Output(
         Path directory,
-        Set<DataType> dataTypes,
-        int flushLimit) {
+        Set<DataType> dataTypes) {
 
       this.directory = directory;
       this.dataTypes = Sets.immutableEnumSet(
           DataType.TOTAL,
           dataTypes.toArray(new DataType[dataTypes.size()]));
-      this.flushLimit = flushLimit;
     }
 
     private StringBuilder asString() {
       return new StringBuilder()
           .append(LOG_INDENT).append("Output")
           .append(formatEntry(Key.DIRECTORY, directory.toAbsolutePath().normalize()))
-          .append(formatEntry(Key.DATA_TYPES, enumsToString(dataTypes, DataType.class)))
-          .append(formatEntry(Key.FLUSH_LIMIT, flushLimit));
+          .append(formatEntry(Key.DATA_TYPES, enumsToString(dataTypes, DataType.class)));
     }
 
     private static final class Builder {
 
       Path directory;
       Set<DataType> dataTypes;
-      Integer flushLimit;
 
       Output build() {
         return new Output(
             directory,
-            dataTypes,
-            flushLimit);
+            dataTypes);
       }
 
       void copy(Output that) {
         this.directory = that.directory;
         this.dataTypes = that.dataTypes;
-        this.flushLimit = that.flushLimit;
       }
 
       void extend(Builder that) {
@@ -998,23 +983,18 @@ public final class CalcConfig {
         if (that.dataTypes != null) {
           this.dataTypes = that.dataTypes;
         }
-        if (that.flushLimit != null) {
-          this.flushLimit = that.flushLimit;
-        }
       }
 
       static Builder defaults() {
         Builder b = new Builder();
         b.directory = Paths.get(DEFAULT_OUT);
         b.dataTypes = EnumSet.of(DataType.TOTAL);
-        b.flushLimit = 1;
         return b;
       }
 
       void validate() {
         checkNotNull(directory, STATE_ERROR, Output.ID, Key.DIRECTORY);
         checkNotNull(dataTypes, STATE_ERROR, Output.ID, Key.DATA_TYPES);
-        checkNotNull(flushLimit, STATE_ERROR, Output.ID, Key.FLUSH_LIMIT);
       }
     }
   }
@@ -1180,7 +1160,6 @@ public final class CalcConfig {
     /* output */
     DIRECTORY,
     DATA_TYPES,
-    FLUSH_LIMIT,
     /* deagg */
     BINS,
     CONTRIBUTOR_LIMIT,

--- a/src/gov/usgs/earthquake/nshmp/calc/DeaggExport.java
+++ b/src/gov/usgs/earthquake/nshmp/calc/DeaggExport.java
@@ -1,6 +1,5 @@
 package gov.usgs.earthquake.nshmp.calc;
 
-import static gov.usgs.earthquake.nshmp.calc.HazardExport.WRITE;
 import static gov.usgs.earthquake.nshmp.internal.TextUtils.NEWLINE;
 import static java.lang.Math.exp;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -77,7 +76,7 @@ final class DeaggExport {
     this.dc = dc;
     this.id = id;
 
-    summary = summaryFlag ? createSummaryElements(ddTotal, dd, dc): null;
+    summary = summaryFlag ? createSummaryElements(ddTotal, dd, dc) : null;
     data = εDataFlag ? createDistanceMagnitudeData(ddTotal, dd) : null;
     sources = jsonFlag ? createJsonContributorList(ddTotal, dd, dc.contributorLimit) : null;
   }
@@ -88,16 +87,14 @@ final class DeaggExport {
     Path dataPath = siteDir.resolve(DEAGG_DATA);
     Files.write(
         dataPath,
-        data.toString().getBytes(UTF_8),
-        WRITE);
+        data.toString().getBytes(UTF_8));
     Path summaryPath = siteDir.resolve(DEAGG_SUMMARY);
     String summaryString = summaryStringBuilder()
         .append(DATASET_SEPARATOR)
         .toString();
     Files.write(
         summaryPath,
-        summaryString.getBytes(UTF_8),
-        WRITE);
+        summaryString.getBytes(UTF_8));
   }
 
   @Override

--- a/src/gov/usgs/earthquake/nshmp/calc/EqRateExport.java
+++ b/src/gov/usgs/earthquake/nshmp/calc/EqRateExport.java
@@ -1,17 +1,12 @@
 package gov.usgs.earthquake.nshmp.calc;
 
 import static com.google.common.base.Preconditions.checkState;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.APPEND;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.OpenOption;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.logging.Logger;
 
@@ -19,10 +14,10 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.primitives.Doubles;
 
 import gov.usgs.earthquake.nshmp.data.XySequence;
+import gov.usgs.earthquake.nshmp.eq.model.HazardModel;
 import gov.usgs.earthquake.nshmp.eq.model.SourceType;
 import gov.usgs.earthquake.nshmp.geo.Location;
 import gov.usgs.earthquake.nshmp.internal.Parsing;
@@ -44,7 +39,7 @@ public final class EqRateExport {
   private final Path dir;
   private final String file;
   private final String valueFormat;
-  private final CalcConfig config;
+  private final HazardModel model;
   private final boolean exportSource;
 
   private final Stopwatch batchWatch;
@@ -53,12 +48,14 @@ public final class EqRateExport {
   private int resultCount = 0;
 
   private final boolean namedSites;
-  private boolean firstBatch = true;
+  private boolean firstRecord = true;
   private boolean used = false;
 
-  private final List<EqRate> rates;
-
-  private EqRateExport(CalcConfig config, Sites sites, Logger log) throws IOException {
+  private EqRateExport(
+      HazardModel model,
+      CalcConfig config,
+      Sites sites,
+      Logger log) throws IOException {
 
     // whether or not rates or probabilities have been calculated
     boolean rates = config.rate.valueFormat == ValueFormat.ANNUAL_RATE;
@@ -67,9 +64,8 @@ public final class EqRateExport {
     this.dir = HazardExport.createOutputDir(config.output.directory);
     this.file = rates ? RATE_FILE : PROB_FILE;
     this.valueFormat = rates ? RATE_FORMAT : PROB_FORMAT;
-    this.config = config;
+    this.model = model;
     this.exportSource = config.output.dataTypes.contains(DataType.SOURCE);
-    this.rates = new ArrayList<>();
 
     Site demoSite = sites.iterator().next();
     this.namedSites = demoSite.name() != Site.NO_NAME;
@@ -81,6 +77,7 @@ public final class EqRateExport {
   /**
    * Create a new results handler.
    * 
+   * @param model being run
    * @param config that specifies output options and formats
    * @param sites reference to the sites to be processed (not retained)
    * @param log shared logging instance from calling class
@@ -89,22 +86,12 @@ public final class EqRateExport {
    *         extents.
    */
   public static EqRateExport create(
+      HazardModel model,
       CalcConfig config,
       Sites sites,
       Logger log) throws IOException {
 
-    return new EqRateExport(config, sites, log);
-  }
-
-  /**
-   * Add the supplied {@code EqRate}s to this exporter.
-   * 
-   * @param rates data containers to add
-   */
-  public void addAll(Collection<EqRate> rates) throws IOException {
-    for (EqRate rate : rates) {
-      add(rate);
-    }
+    return new EqRateExport(model, config, sites, log);
   }
 
   /**
@@ -112,12 +99,11 @@ public final class EqRateExport {
    * 
    * @param rate data container to add
    */
-  public void add(EqRate rate) throws IOException {
+  public void write(EqRate rate) throws IOException {
     checkState(!used, "This result handler is expired");
+    writeRate(rate);
     resultCount++;
-    rates.add(rate);
-    if (rates.size() == config.output.flushLimit) {
-      flush();
+    if (resultCount % 10 == 0) {
       batchCount++;
       log.info(String.format(
           "     batch: %s in %s – %s sites in %s",
@@ -131,35 +117,16 @@ public final class EqRateExport {
    * exporter to 'used'; no more results may be added.
    */
   public void expire() throws IOException {
-    flush();
     batchWatch.stop();
     totalWatch.stop();
     used = true;
   }
 
-  /*
-   * Flush any stored Hazard and Deaggregation results to file, clearing
-   */
-  private void flush() throws IOException {
-    if (!rates.isEmpty()) {
-      writeRates();
-      rates.clear();
-      firstBatch = false;
-    }
-  }
-
   /**
-   * The number of hazard [and deagg] results passed to this handler thus far.
+   * The number of rate results passed to this handler thus far.
    */
-  public int resultsProcessed() {
+  public int resultCount() {
     return resultCount;
-  }
-
-  /**
-   * The number of {@code Hazard} results this handler is currently storing.
-   */
-  public int size() {
-    return rates.size();
   }
 
   /**
@@ -180,74 +147,63 @@ public final class EqRateExport {
   /*
    * Write the current list of {@code EqRate}s to file.
    */
-  private void writeRates() throws IOException {
+  private void writeRate(EqRate rate) throws IOException {
 
-    EqRate demo = rates.get(0);
-
-    Iterable<Double> emptyValues = Doubles.asList(new double[demo.totalMfd.size()]);
-
-    OpenOption[] options = firstBatch ? HazardExport.WRITE : HazardExport.APPEND;
-
+    Iterable<Double> emptyValues = Doubles.asList(new double[rate.totalMfd.size()]);
     Function<Double, String> formatter = Parsing.formatDoubleFunction(valueFormat);
 
-    /* Line maps for ascii output; may or may not be used */
-    List<String> totalLines = new ArrayList<>();
-    Map<SourceType, List<String>> typeLines = Maps.newEnumMap(SourceType.class);
-
-    if (firstBatch) {
-      Iterable<?> header = Iterables.concat(
-          Lists.newArrayList(namedSites ? "name" : null, "lon", "lat"),
-          demo.totalMfd.xValues());
-      totalLines.add(Parsing.join(header, Delimiter.COMMA));
+    /* Can't init output until we have a demo rate record for mfd x-values */
+    if (firstRecord) {
+      init(rate);
+      firstRecord = false;
     }
+
+    String name = namedSites ? rate.site.name : null;
+    Location location = rate.site.location;
+
+    List<String> locData = Lists.newArrayList(
+        name,
+        String.format("%.5f", location.lon()),
+        String.format("%.5f", location.lat()));
+
+    String totalLine = toLine(locData, rate.totalMfd.yValues(), formatter);
+
+    String emptyLine = toLine(locData, emptyValues, formatter);
+
+    /* write/append */
+    Path totalFile = dir.resolve(file);
+    HazardExport.writeLine(totalFile, totalLine, APPEND);
+    if (exportSource) {
+      Path parentDir = dir.resolve(HazardExport.TYPE_DIR);
+      for (SourceType type : model.types()) {
+        Path typeFile = parentDir.resolve(type.name()).resolve(file);
+        String typeLine = emptyLine;
+        if (rate.typeMfds.containsKey(type)) {
+          XySequence typeRate = rate.typeMfds.get(type);
+          typeLine = toLine(locData, typeRate.yValues(), formatter);
+        }
+        HazardExport.writeLine(typeFile, typeLine, APPEND);
+      }
+    }
+  }
+
+  private void init(EqRate demo) throws IOException {
+    Iterable<?> headerElements = Iterables.concat(
+        Lists.newArrayList(namedSites ? "name" : null, "lon", "lat"),
+        demo.totalMfd.xValues());
+    String header = Parsing.join(headerElements, Delimiter.COMMA);
+    Path totalFile = dir.resolve(file);
+    HazardExport.writeLine(totalFile, header);
 
     if (exportSource) {
+      Path parentDir = dir.resolve(HazardExport.TYPE_DIR);
+      Files.createDirectory(parentDir);
       // TODO get source types from model
-      for (SourceType type : SourceType.values()) {
-        typeLines.put(type, Lists.newArrayList(totalLines));
-      }
-    }
-
-    /* Process batch */
-    for (EqRate rate : rates) {
-
-      String name = namedSites ? rate.site.name : null;
-      Location location = rate.site.location;
-
-      List<String> locData = Lists.newArrayList(
-          name,
-          String.format("%.5f", location.lon()),
-          String.format("%.5f", location.lat()));
-
-      String line = toLine(locData, rate.totalMfd.yValues(), formatter);
-      totalLines.add(line);
-
-      String emptyLine = toLine(locData, emptyValues, formatter);
-
-      if (exportSource) {
-        for (Entry<SourceType, List<String>> entry : typeLines.entrySet()) {
-          SourceType type = entry.getKey();
-          String typeLine = emptyLine;
-          if (rate.typeMfds.containsKey(type)) {
-            XySequence typeRate = rate.typeMfds.get(type);
-            typeLine = toLine(locData, typeRate.yValues(), formatter);
-          }
-          entry.getValue().add(typeLine);
-        }
-      }
-
-      /* write/append */
-      Path totalFile = dir.resolve(file);
-      Files.write(totalFile, totalLines, UTF_8, options);
-      if (exportSource) {
-        Path parentDir = dir.resolve(HazardExport.TYPE_DIR);
-        for (Entry<SourceType, List<String>> typeEntry : typeLines.entrySet()) {
-          SourceType type = typeEntry.getKey();
-          Path typeDir = parentDir.resolve(type.name());
-          Files.createDirectories(typeDir);
-          Path typeFile = typeDir.resolve(file);
-          Files.write(typeFile, typeEntry.getValue(), UTF_8, options);
-        }
+      for (SourceType type : model.types()) {
+        Path typeDir = parentDir.resolve(type.name());
+        Files.createDirectory(typeDir);
+        Path typeFile = typeDir.resolve(file);
+        HazardExport.writeLine(typeFile, header);
       }
     }
   }


### PR DESCRIPTION
* Removed config.flushLimit
* Exporters have direct `write()` methods
* No queueing/caching of results before writing