### PR TITLE
Improve Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,8 @@ LABEL maintainer="Peter Powers <pmpowers@usgs.gov>"
 WORKDIR /app
 
 RUN yum update -y
-RUN yum install -y file epel-release
-RUN yum install -y jq
+RUN yum install -y file epel-release && rm -rf /var/cache/yum
+RUN yum install -y jq && rm -rf /var/cache/yum
 
 ARG jar_path
 ARG builder_workdir


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

The change I made:
* I remove the yum cache after the `yum install` which reduces the size of the final image.

Impact on the image size:
* Image size before repair: 1.39 GB
* Image size after repair: 832.68 MB
* Difference: 586.33 MB (41.32%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,